### PR TITLE
Client/cvm menuview searchbar fix

### DIFF
--- a/client/app/components/Searchbar.js
+++ b/client/app/components/Searchbar.js
@@ -12,8 +12,13 @@ export class Searchbar extends Component {
 
     // Sets the local state of text input to be the search term
     setSearchTerm = (searchTerm) => {
-        this.setState({searchTerm});
-        this.props.autoUpdate && this.onSearch(); // will perform on search on text change if 'autoupdate' is true
+        this.setState({searchTerm}, () => { // setState is actually async and needs to run these functions
+                                            // only on the new state!
+            this.props.onChangeText && this.props.onChangeText(searchTerm); // will run a function 
+                                                                            // if onChangeText prop is passed in
+            this.props.autoUpdate && this.onSearch(); // will perform on search on text change 
+                                                      // if 'autoUpdate' is true
+        })
     }
 
     // Autoresizes TextInput height on text change

--- a/client/app/views/MenuView.js
+++ b/client/app/views/MenuView.js
@@ -22,17 +22,29 @@ class MenuView extends Component {
     state = {
         mealArray: undefined,
         mealArrayFiltered: undefined,
+        searchTerm: "",
         hoursMessage: ""
     }
 
-    performSearch = (searchTerm) => {
-        if (searchTerm === "") {
-            this.setState({mealArrayFiltered: this.state.mealArray});
-            return;
-        }
+    // We need to call performSearch with the new
+    // search term when a top tab is pressed,
+    // so we need to keep a local state of the search term
+    updateSearchTerm = (searchTerm) => {
+        this.setState({ searchTerm: searchTerm });
+    }
 
-        const mealArrayFiltered = search(searchTerm, this.state.mealArray, ['name']);
-        this.setState({mealArrayFiltered});
+    performSearch = (searchTerm) => {
+        // If the search term is empty
+        // just output everything
+        if (searchTerm.trim() == "") {
+            this.setState({
+                mealArrayFiltered: this.state.mealArray
+            })
+        // Otherwise do an actual search on the array
+        } else {
+            const mealArrayFiltered = search(searchTerm, this.state.mealArray, ['name']);
+            this.setState({mealArrayFiltered});
+        }
     }
 
     generateHoursMessage = (mealType) => {
@@ -65,7 +77,9 @@ class MenuView extends Component {
                     const mealArray = this.props.menusList.data.today[mealType];
                     const mealArrayFiltered = mealArray;
                     const hoursMessage = this.generateHoursMessage(mealType);
-                    this.setState({ mealArray, mealArrayFiltered, hoursMessage })
+                    this.setState({ mealArray, mealArrayFiltered, hoursMessage }, () => {
+                        this.performSearch(this.state.searchTerm);
+                    })
                 }
             }
         })
@@ -81,7 +95,7 @@ class MenuView extends Component {
                 {hasLoadedSuccessfully &&
                     <View>
                         <Header canGoBack title={this.props.menusList.data.location} />
-                        <Searchbar autoUpdate onSearch={this.performSearch} />
+                        <Searchbar autoUpdate onSearch={this.performSearch} onChangeText={this.updateSearchTerm} />
                         <TopTabs tabButtons={this.dynamicTabButtons()} />
                         <Text style={{ ...styles.font.type.primaryRegular, ...styles.font.color.primary, textAlign: 'center' }}>{this.state.hoursMessage}</Text>
                         {this.state.mealArrayFiltered && <View>


### PR DESCRIPTION
# MenuView/Searchbar Fix

## Changes
Results shown in search results did not match results in search term due to not handling of async `setState`. > Yes, apparently `setState` is an async operation for performance reasons, so if you want to do something immediately after with the new state, you need to pass in a callback to `setState`! Doing this in `MenuView` and `Searchbar` fixed the searching issue.
Passed the `searchTerm` value up from `Searchbar` into `MenuView`'s local state to run `this.performSearch(this.state.searchTerm)` on every Top Tab press.

## Screenshots
![Screenshot_20190401-162714_Expo](https://user-images.githubusercontent.com/22136259/55358308-11fe7c00-549d-11e9-9448-cb825f6905f3.jpg)
![Screenshot_20190401-162721_Expo](https://user-images.githubusercontent.com/22136259/55358310-14f96c80-549d-11e9-8b20-96f5d55e61d8.jpg)


## Testing
Mah eyeballs 👀 .