### PR TITLE
client/sk-fixBoolFilters

### DIFF
--- a/client/app/components/Ingredients.js
+++ b/client/app/components/Ingredients.js
@@ -26,9 +26,13 @@ class Ingredients extends Component {
     render() {
         return (
             <View style={{ flex: 1 }}>
-                <BoolFilters vegan={this.props.menuItem.data.isVegan} 
-                    veg={this.props.menuItem.data.isVegetarian}
-                    gf={this.props.menuItem.data.isGlutenFree}/>
+                { (this.props.menuItem.data.isVegan || 
+                    this.props.menuItem.data.isVegetarian || 
+                    this.props.menuItem.data.isGlutenFree) &&
+                    <BoolFilters vegan={this.props.menuItem.data.isVegan} 
+                        veg={this.props.menuItem.data.isVegetarian}
+                        gf={this.props.menuItem.data.isGlutenFree}/>
+                }
                 <Transition appear="bottom">
                     <DV2ScrollView
                         style={{ flex: 1 }}


### PR DESCRIPTION
Fixing BoolFilters to display only if at least one filter true. This should remove some of the unnecessary space that came in when no filters present.