### PR TITLE
server/zm-getExpoTokens

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -7877,6 +7877,15 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "node-cron": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-2.0.3.tgz",
+      "integrity": "sha512-eJI+QitXlwcgiZwNNSRbqsjeZMp5shyajMR81RZCqeW0ZDEj4zU9tpd4nTh/1JsBiKbF8d08FCewiipDmVIYjg==",
+      "requires": {
+        "opencollective-postinstall": "^2.0.0",
+        "tz-offset": "0.0.1"
+      }
+    },
     "node-fetch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
@@ -8106,6 +8115,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+    },
+    "opencollective-postinstall": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
     },
     "opn": {
       "version": "5.5.0",
@@ -10246,6 +10260,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "optional": true
+    },
+    "tz-offset": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tz-offset/-/tz-offset-0.0.1.tgz",
+      "integrity": "sha512-kMBmblijHJXyOpKzgDhKx9INYU4u4E1RPMB0HqmKSgWG8vEcf3exEfLh4FFfzd3xdQOw9EuIy/cP0akY6rHopQ=="
     },
     "uglify-js": {
       "version": "3.4.9",

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
         "firebase": "^5.9.2",
         "firebase-admin": "^7.2.0",
         "firebase-tools": "^6.5.0",
+        "node-cron": "^2.0.3",
         "request": "^2.88.0"
     },
     "devDependencies": {

--- a/server/src/config/constants.js
+++ b/server/src/config/constants.js
@@ -1,0 +1,18 @@
+export const MENUS_URI =
+    "http://www.yaledining.org/fasttrack/menus.cfm?version=3";
+export const NUTRITION_URI =
+    "http://www.yaledining.org/fasttrack/menuitem-nutrition.cfm?version=3";
+export const FILTERS_URI =
+    "http://www.yaledining.org/fasttrack/menuitem-codes.cfm?version=3";
+export const INGREDIENTS_URI =
+    "http://www.yaledining.org/fasttrack/menuitem-ingredients.cfm?version=3";
+
+export const E_NO_API_RES = "Empty object returned from YaleDining API";
+
+export const E_BAD_LOC_REQ = "Invalid location request";
+export const E_BAD_MENU_REQ = "Invalid menu request";
+export const E_BAD_FAVE_REQ = "Push token and item ID are required";
+
+export const E_DB_READ = "Error getting document: ";
+export const E_DB_WRITE = "Could not write document: ";
+export const E_DB_NOENT = "Document does not exist: ";

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,10 +1,13 @@
 import express from "express";
 import bodyParser from "body-parser";
+import cron from "node-cron";
 
 import LocationsRouter from "./routers/LocationsRouter/LocationsRouter";
 import MenusRouter from "./routers/MenusRouter/MenusRouter";
 import MenuItemsRouter from "./routers/MenuItemsRouter/MenuItemsRouter";
 import FavoritesRouter from "./routers/FavoritesRouter/FavoritesRouter";
+
+import sendNotifications from "./notifications/sendNotifications";
 
 const PORT = process.env.PORT || 5000;
 
@@ -18,8 +21,10 @@ server.use("/api/menus", MenusRouter);
 server.use("/api/menuItems", MenuItemsRouter);
 server.use("/api/favorites", FavoritesRouter);
 
-server.listen(PORT, error => {
-    if (error) {
-        console.log(error);
-    }
-});
+server.listen(PORT, e => e && console.error(e));
+
+const options = {
+    scheduled: true,
+    timezone: "America/New_York"
+};
+cron.schedule("0 0 7 * * *", () => sendNotifications(), options);

--- a/server/src/notifications/getMenuItemsToday.js
+++ b/server/src/notifications/getMenuItemsToday.js
@@ -1,0 +1,44 @@
+import axios from "axios";
+
+import getMenuItemList from "../routers/MenusRouter/getMenuItemList";
+
+import locations from "../config/locations";
+import monthName from "../config/monthName";
+
+const MENUS_URI = "http://www.yaledining.org/fasttrack/menus.cfm?version=3";
+
+export default async function getMenuItemsToday() {
+    // get date for menus -- relies on the fact that server is on EST/EDT
+    const date = new Date();
+    const today =
+        monthName[date.getMonth()] +
+        ", " +
+        date.getDate() +
+        " " +
+        date.getFullYear() +
+        " 00:00:00";
+    var completeMenuItemList = [];
+    for (let location in locations) {
+        const endpoint = MENUS_URI + "&location=" + location;
+        const response = await axios.get(endpoint);
+        const filteredData = response.data.DATA.filter(
+            entry => entry[response.data.COLUMNS.indexOf("MENUDATE")] == today
+        );
+        const menuItemList = getMenuItemList(
+            response.data.COLUMNS,
+            filteredData
+        );
+        menuItemList &&
+            menuItemList.forEach(item => completeMenuItemList.push(item));
+    }
+    completeMenuItemList = completeMenuItemList.filter(
+        (entry, index, self) =>
+            index ===
+            self.findIndex(
+                otherEntry =>
+                    otherEntry.name === entry.name &&
+                    otherEntry.itemID === entry.itemID
+            )
+    );
+    return completeMenuItemList.length ? completeMenuItemList : undefined;
+}

--- a/server/src/notifications/getMenuItemsToday.js
+++ b/server/src/notifications/getMenuItemsToday.js
@@ -29,16 +29,59 @@ export default async function getMenuItemsToday() {
             filteredData
         );
         menuItemList &&
-            menuItemList.forEach(item => completeMenuItemList.push(item));
+            menuItemList.forEach(item =>
+                completeMenuItemList.push({
+                    name: item.name,
+                    itemID: item.itemID,
+                    meal: item.meal,
+                    location: locations[location]
+                })
+            );
     }
-    completeMenuItemList = completeMenuItemList.filter(
-        (entry, index, self) =>
-            index ===
-            self.findIndex(
+    // unset location and/or meal for duplicate items
+    completeMenuItemList = completeMenuItemList
+        // set the first occurence of a duplicated item to have undefined location
+        .map((entry, index, self) => {
+            let otherIndex = self.findIndex(
                 otherEntry =>
                     otherEntry.name === entry.name &&
-                    otherEntry.itemID === entry.itemID
-            )
-    );
+                    otherEntry.itemID === entry.itemID &&
+                    otherEntry.meal === entry.meal &&
+                    otherEntry.location != entry.location
+            );
+            return otherIndex == -1 ? entry : { ...entry, location: undefined };
+        })
+        // remove all later duplicated items
+        .filter(
+            (entry, index, self) =>
+                index ===
+                self.findIndex(
+                    otherEntry =>
+                        otherEntry.name === entry.name &&
+                        otherEntry.itemID === entry.itemID &&
+                        otherEntry.meal === entry.meal
+                )
+        )
+        // set the first occurence of a duplicated item to have undefined meal
+        .map((entry, index, self) => {
+            let otherIndex = self.findIndex(
+                otherEntry =>
+                    otherEntry.name === entry.name &&
+                    otherEntry.itemID === entry.itemID &&
+                    otherEntry.meal != entry.meal &&
+                    otherEntry.location === entry.location
+            );
+            return otherIndex == -1 ? entry : { ...entry, meal: undefined };
+        })
+        // remove all later duplicated items
+        .filter(
+            (entry, index, self) =>
+                index ===
+                self.findIndex(
+                    otherEntry =>
+                        otherEntry.name === entry.name &&
+                        otherEntry.itemID === entry.itemID
+                )
+        );
     return completeMenuItemList.length ? completeMenuItemList : undefined;
 }

--- a/server/src/notifications/getPushTokens.js
+++ b/server/src/notifications/getPushTokens.js
@@ -19,6 +19,7 @@ export default async function getPushTokens(menuItems) {
                 expoTokens.push({
                     name: menuItem.name,
                     meal: menuItem.meal,
+                    location: menuItem.location,
                     token: token
                 })
             );
@@ -30,7 +31,27 @@ export default async function getPushTokens(menuItems) {
     });
     const tokens = expoTokens.map(token => {
         // TODO: add extra information to the body
-        let body = token.name + " is being served today!";
+        let body = undefined;
+        if (token.meal && token.location) {
+            body =
+                token.name +
+                " is being served for " +
+                token.meal +
+                " at " +
+                token.location +
+                " today!";
+        } else if (token.meal) {
+            body =
+                token.name + " is being served for " + token.meal + " today!";
+        } else if (token.location) {
+            body =
+                token.name +
+                " is being served at " +
+                token.location +
+                " today!";
+        } else {
+            body = token.name + " is being served today!";
+        }
         return {
             to: token.token,
             sound: "default",

--- a/server/src/notifications/getPushTokens.js
+++ b/server/src/notifications/getPushTokens.js
@@ -1,0 +1,42 @@
+import firestore from "../config/firebase/firebaseConfig";
+
+export default async function getPushTokens(menuItems) {
+    let menuItemsDoc = undefined;
+    try {
+        menuItemsDoc = await firestore.doc("favorites/menuItems").get();
+    } catch (e) {
+        throw new Error("Error getting document: " + e);
+    }
+    if (!menuItemsDoc.exists) {
+        throw new Error("Document favorites/menuItems does not exist");
+    } else if (!menuItems) {
+        throw new Error("No menus received for today");
+    }
+    var expoTokens = [];
+    menuItems.forEach(async menuItem => {
+        if (menuItemsDoc.data()[menuItem.itemID]) {
+            menuItemsDoc.data()[menuItem.itemID].forEach(token =>
+                expoTokens.push({
+                    name: menuItem.name,
+                    meal: menuItem.meal,
+                    token: token
+                })
+            );
+        } else {
+            await firestore
+                .doc("favorites/menuItems")
+                .update({ [menuItem.itemID]: [] });
+        }
+    });
+    const tokens = expoTokens.map(token => {
+        // TODO: add extra information to the body
+        let body = token.name + " is being served today!";
+        return {
+            to: token.token,
+            sound: "default",
+            body: body,
+            data: {}
+        };
+    });
+    return tokens;
+}

--- a/server/src/notifications/sendNotifications.js
+++ b/server/src/notifications/sendNotifications.js
@@ -1,0 +1,9 @@
+import getMenuItemsToday from "./getMenuItemsToday";
+import getPushTokens from "./getPushTokens";
+
+export default async function sendNotifications() {
+    const menuItems = await getMenuItemsToday();
+    const tokens = await getPushTokens(menuItems);
+    // TODO: call method to send the push tokens to expo
+    return tokens;
+}

--- a/server/src/routers/FavoritesRouter/FavoritesRouter.js
+++ b/server/src/routers/FavoritesRouter/FavoritesRouter.js
@@ -11,7 +11,7 @@ router
             await addFavorite(req.body.token, req.body.menuitemid);
             res.sendStatus(200);
         } catch (e) {
-            console.warn(e);
+            console.error(e);
             res.sendStatus(500);
         }
     })
@@ -20,7 +20,7 @@ router
             await removeFavorite(req.body.token, req.body.menuitemid);
             res.sendStatus(200);
         } catch (e) {
-            console.warn(e);
+            console.error(e);
             res.sendStatus(500);
         }
     });

--- a/server/src/routers/FavoritesRouter/addFavorite.js
+++ b/server/src/routers/FavoritesRouter/addFavorite.js
@@ -13,6 +13,6 @@ export default async function addFavorite(token, menuItemID) {
             [token]: firebase.firestore.FieldValue.arrayUnion(menuItemID)
         });
     } catch (e) {
-        console.error("Error writing document: ", e);
+        throw new Error("Could not write document: " + e);
     }
 }

--- a/server/src/routers/FavoritesRouter/addFavorite.js
+++ b/server/src/routers/FavoritesRouter/addFavorite.js
@@ -1,9 +1,11 @@
 import * as firebase from "firebase-admin";
 import firestore from "../../config/firebase/firebaseConfig";
 
+import { E_BAD_FAVE_REQ, E_DB_WRITE } from "../../config/constants";
+
 export default async function addFavorite(token, menuItemID) {
     if (!token || !menuItemID) {
-        throw new Error("Push token and item ID are required");
+        throw new Error(E_BAD_FAVE_REQ);
     }
     try {
         await firestore.doc("favorites/menuItems").update({
@@ -13,6 +15,6 @@ export default async function addFavorite(token, menuItemID) {
             [token]: firebase.firestore.FieldValue.arrayUnion(menuItemID)
         });
     } catch (e) {
-        throw new Error("Could not write document: " + e);
+        throw new Error(E_DB_WRITE + e);
     }
 }

--- a/server/src/routers/FavoritesRouter/removeFavorite.js
+++ b/server/src/routers/FavoritesRouter/removeFavorite.js
@@ -1,9 +1,10 @@
 import * as firebase from "firebase-admin";
 import firestore from "../../config/firebase/firebaseConfig";
+import { E_BAD_FAVE_REQ, E_DB_WRITE } from "../../config/constants";
 
 export default async function removeFavorite(token, menuItemID) {
     if (!token || !menuItemID) {
-        throw new Error("Push token and item ID are required");
+        throw new Error(E_BAD_FAVE_REQ);
     }
     try {
         await firestore.doc("favorites/menuItems").update({
@@ -13,6 +14,6 @@ export default async function removeFavorite(token, menuItemID) {
             [token]: firebase.firestore.FieldValue.arrayRemove(menuItemID)
         });
     } catch (e) {
-        throw new Error("Could not write document: " + e);
+        throw new Error(E_DB_WRITE + e);
     }
 }

--- a/server/src/routers/FavoritesRouter/removeFavorite.js
+++ b/server/src/routers/FavoritesRouter/removeFavorite.js
@@ -13,6 +13,6 @@ export default async function removeFavorite(token, menuItemID) {
             [token]: firebase.firestore.FieldValue.arrayRemove(menuItemID)
         });
     } catch (e) {
-        console.error("Error writing document: ", e);
+        throw new Error("Could not write document: " + e);
     }
 }

--- a/server/src/routers/LocationsRouter/LocationsRouter.js
+++ b/server/src/routers/LocationsRouter/LocationsRouter.js
@@ -9,7 +9,7 @@ router.get("/", async (req, res) => {
         const location = await getLocations(req.query);
         res.send(location);
     } catch (e) {
-        console.warn(e);
+        console.error(e);
         if (e.message == "Invalid location request") {
             res.sendStatus(400);
         } else {

--- a/server/src/routers/LocationsRouter/getHours.js
+++ b/server/src/routers/LocationsRouter/getHours.js
@@ -1,29 +1,19 @@
 import axios from "axios";
 
 import mealNames from "../../config/mealNames";
-import monthName from "../../config/monthName";
-import locations from "../../config/locations";
-import diningHallHours from "../../config/diningHallHours";
-
-const MENUS_URI = "http://www.yaledining.org/fasttrack/menus.cfm?version=3";
+import queryBuilder from "../../util/queryBuilder";
+import dateBuilder from "../../util/dateBuilder";
+import { MENUS_URI, E_NO_API_RES } from "../../config/constants";
 
 export default async function getHours(location, offset) {
-    const endpoint = MENUS_URI + "&location=" + location;
+    const endpoint = MENUS_URI + queryBuilder({ location });
     const response = await axios.get(endpoint);
     const data = response.data;
     // throw on bad response from Yale Dining
     if (!data || !data.DATA || !data.DATA.length || !data.DATA[0].length) {
-        throw new Error("Empty object returned from YaleDining API");
+        throw new Error(E_NO_API_RES);
     }
-    // get date for menus -- relies on the fact that server is on EST/EDT
-    const currentDate = new Date();
-    const date =
-        monthName[currentDate.getMonth()] +
-        ", " +
-        (currentDate.getDate() + offset) +
-        " " +
-        currentDate.getFullYear() +
-        " 00:00:00";
+    const date = dateBuilder(offset);
     const dateFilteredData = data.DATA.filter(
         entry => entry[data.COLUMNS.indexOf("MENUDATE")] === date
     );

--- a/server/src/routers/LocationsRouter/getOneLocation.js
+++ b/server/src/routers/LocationsRouter/getOneLocation.js
@@ -1,5 +1,7 @@
 import getHours from "./getHours";
 
+import { E_BAD_LOC_REQ } from "../../config/constants";
+
 export default async function getOneLocation(data, query) {
     const location = data.DATA.filter(
         entry => entry[data.COLUMNS.indexOf("ID_LOCATION")] == query.location
@@ -19,6 +21,6 @@ export default async function getOneLocation(data, query) {
                 .map(v => parseFloat(v))
         };
     } else {
-        throw new Error("Invalid location request");
+        throw new Error(E_BAD_LOC_REQ);
     }
 }

--- a/server/src/routers/LocationsRouter/processLocations.js
+++ b/server/src/routers/LocationsRouter/processLocations.js
@@ -16,10 +16,13 @@ export default async function processLocations(data, query) {
         for (let location in locations) {
             try {
                 query["location"] = location;
-                allLocations[locations[location]] = await getOneLocation(data, query);
+                allLocations[locations[location]] = await getOneLocation(
+                    data,
+                    query
+                );
             } catch (e) {
                 nErrors++;
-                console.warn(
+                console.error(
                     e.message +
                         " for: " +
                         locations[location] +

--- a/server/src/routers/LocationsRouter/processLocations.js
+++ b/server/src/routers/LocationsRouter/processLocations.js
@@ -1,10 +1,12 @@
-import locations from "../../config/locations";
 import getOneLocation from "./getOneLocation";
+
+import locations from "../../config/locations";
+import { E_NO_API_RES } from "../../config/constants";
 
 export default async function processLocations(data, query) {
     // throw on bad response from Yale Dining
     if (!data || !data.DATA || !data.DATA.length || !data.DATA[0].length) {
-        throw new Error("Empty object returned from YaleDining API");
+        throw new Error(E_NO_API_RES);
     }
 
     if ("location" in query) {
@@ -22,18 +24,13 @@ export default async function processLocations(data, query) {
                 );
             } catch (e) {
                 nErrors++;
+                const message = e.message;
+                const readableLocation = locations[location];
                 console.error(
-                    e.message +
-                        " for: " +
-                        locations[location] +
-                        " (total: " +
-                        nErrors +
-                        ")"
+                    `${message}: ${readableLocation} (total: ${nErrors})`
                 );
                 if (nErrors >= maxErrors) {
-                    throw new Error(
-                        "Empty object returned from YaleDining API"
-                    );
+                    throw new Error(E_NO_API_RES);
                 }
             }
         }

--- a/server/src/routers/MenuItemsRouter/MenuItemsRouter.js
+++ b/server/src/routers/MenuItemsRouter/MenuItemsRouter.js
@@ -1,21 +1,19 @@
-import express from 'express';
-import getMenuIdInfo from './getMenuIdInfo';
+import express from "express";
+import getMenuIdInfo from "./getMenuIdInfo";
 
 const router = express.Router();
 export default router;
 
-router.get('/', async (req, res) => {
-    if (!('menuitemid' in req.query)) {
-        console.warn("menuitemid is an essential parameter");
+router.get("/", async (req, res) => {
+    if (!("menuitemid" in req.query)) {
+        console.error("menuitemid is an essential parameter");
         res.sendStatus(400);
-    }
-    else {
-        try{
+    } else {
+        try {
             const menu = await getMenuIdInfo(req.query.menuitemid);
             res.send(menu);
-        } 
-        catch (e) {
-            console.warn(e);
+        } catch (e) {
+            console.error(e);
             res.sendStatus(500);
         }
     }

--- a/server/src/routers/MenuItemsRouter/getMenuIdInfo.js
+++ b/server/src/routers/MenuItemsRouter/getMenuIdInfo.js
@@ -1,33 +1,43 @@
-import axios from 'axios';
+import axios from "axios";
 
-import parseMenuItemData from './parseMenuItemData';
+import parseMenuItemData from "./parseMenuItemData";
 
-const NUTRITION_URI = 'http://www.yaledining.org/fasttrack/menuitem-nutrition.cfm?version=3';
-const FILTERS_URI = 'http://www.yaledining.org/fasttrack/menuitem-codes.cfm?version=3';
-const INGREDIENTS_URI = 'http://www.yaledining.org/fasttrack/menuitem-ingredients.cfm?version=3';
+import queryBuilder from "../../util/queryBuilder";
+import {
+    NUTRITION_URI,
+    FILTERS_URI,
+    INGREDIENTS_URI,
+    E_NO_API_RES
+} from "../../config/constants";
 
 /**
  * Gets nutrition, filters (allergans, etc), and ingredients data from dining api
- * 
+ *
  * thorws if an error caught by one of the dining api calls or by the call to parseMenus
  *
  * @param int menuitemid
- * 
+ *
  * returns a menu (json format, as specified in spec)
  */
 
 export default async function getMenuIdInfo(menuitemid) {
-    const nutritionEndpoint = NUTRITION_URI + '&MENUITEMID=' + menuitemid;
-    const filterEndpoint = FILTERS_URI + '&MENUITEMID=' + menuitemid;
-    const ingredientsEndpoint = INGREDIENTS_URI + '&MENUITEMID=' + menuitemid;
+    const nutritionEndpoint =
+        NUTRITION_URI + queryBuilder({ MENUITEMID: menuitemid });
+    const filterEndpoint =
+        FILTERS_URI + queryBuilder({ MENUITEMID: menuitemid });
+    const ingredientsEndpoint =
+        INGREDIENTS_URI + queryBuilder({ MENUITEMID: menuitemid });
     try {
         const nutritionResponse = await axios.get(nutritionEndpoint);
         const filterResponse = await axios.get(filterEndpoint);
         const ingredientsResponse = await axios.get(ingredientsEndpoint);
-        const menu = parseMenuItemData(nutritionResponse.data, filterResponse.data, ingredientsResponse.data);
+        const menu = parseMenuItemData(
+            nutritionResponse.data,
+            filterResponse.data,
+            ingredientsResponse.data
+        );
         return menu;
-    }
-    catch (e) {
-        throw new Error('Error caught (getMenuIdInfo): ' + menuitemid);
+    } catch (e) {
+        throw new Error(E_NO_API_RES);
     }
 }

--- a/server/src/routers/MenuItemsRouter/parseMenuItemData.js
+++ b/server/src/routers/MenuItemsRouter/parseMenuItemData.js
@@ -1,5 +1,6 @@
 import parseNutritionInfo from "./parseNutritionInfo";
 import filters from "../../config/filters.js";
+import { E_NO_API_RES } from "../../config/constants";
 
 /**
  * Parses and combines the nutrition (by call to parseNutritionInfo),
@@ -28,7 +29,7 @@ export default function parseMenuItemData(
         !nutritionData.DATA.length ||
         !nutritionData.DATA[0].length
     ) {
-        throw new Error("Empty nutrition object returned from YaleDining API");
+        throw new Error(E_NO_API_RES);
     }
     if (
         !filterData ||
@@ -36,7 +37,7 @@ export default function parseMenuItemData(
         !filterData.DATA.length ||
         !filterData.DATA[0].length
     ) {
-        throw new Error("Empty filter object returned from YaleDining API");
+        throw new Error(E_NO_API_RES);
     }
     if (
         !ingredientData ||
@@ -44,7 +45,7 @@ export default function parseMenuItemData(
         !ingredientData.DATA.length ||
         !ingredientData.DATA[0].length
     ) {
-        throw new Error("Empty ingredient object returned from YaleDining API");
+        throw new Error(E_NO_API_RES);
     }
 
     // Process ingredient list
@@ -58,22 +59,23 @@ export default function parseMenuItemData(
     }
     // remove duplicate ingredients
     ingredientList = ingredientList.filter(
-        (entry, index, self) => index === self.findIndex(otherEntry => otherEntry === entry)
+        (entry, index, self) =>
+            index === self.findIndex(otherEntry => otherEntry === entry)
     );
 
     // Process filters
-    var isVegan = false; 
+    var isVegan = false;
     var isVegetarian = false;
     var isGlutenFree = false;
     var filterList = []; // list of applicable filters
     var boolFilters = filterData.DATA[0].slice(2, filters.length + 2);
     filters.map((filter, i) => {
         if (boolFilters[i] == 1) {
-            if (filter == "Vegan") isVegan = true; 
+            if (filter == "Vegan") isVegan = true;
             else if (filter == "Vegetarian") isVegetarian = true;
             else if (filter == "Gluten Free") isVegetarian = true;
             else filterList.push(filter);
-        }   
+        }
     });
 
     return {
@@ -81,9 +83,9 @@ export default function parseMenuItemData(
         nutrition: parseNutritionInfo(nutritionData.DATA[0]),
         ingredients: ingredientList,
         filterProperties: filterList,
-        isVegan: isVegan, 
-        isVegetarian: isVegetarian, 
-        isGlutenFree: isGlutenFree, 
+        isVegan: isVegan,
+        isVegetarian: isVegetarian,
+        isGlutenFree: isGlutenFree,
         rating: 5 // TODO : this line is temporarily hard coded
     };
 }

--- a/server/src/routers/MenusRouter/MenusRouter.js
+++ b/server/src/routers/MenusRouter/MenusRouter.js
@@ -9,7 +9,7 @@ router.get("/", async (req, res) => {
         const menus = await getMenus(req.query);
         res.send(menus);
     } catch (e) {
-        console.warn(e);
+        console.error(e);
         if (e.message == "Invalid menu request") {
             res.sendStatus(400);
         } else {

--- a/server/src/routers/MenusRouter/getAllMenus.js
+++ b/server/src/routers/MenusRouter/getAllMenus.js
@@ -27,7 +27,7 @@ export default async function getAllMenus(query) {
             menus.forEach(menu => allMenus.push(menu));
         } catch (e) {
             nErrors++;
-            console.warn(
+            console.error(
                 e.message +
                     ": " +
                     locations[location] +

--- a/server/src/routers/MenusRouter/getAllMenus.js
+++ b/server/src/routers/MenusRouter/getAllMenus.js
@@ -1,5 +1,7 @@
 import getOneMenu from "./getOneMenu";
+
 import locations from "../../config/locations";
+import { E_NO_API_RES } from "../../config/constants";
 
 /*
  *   getAllMenus(query)
@@ -27,28 +29,25 @@ export default async function getAllMenus(query) {
             menus.forEach(menu => allMenus.push(menu));
         } catch (e) {
             nErrors++;
+            const message = e.message;
+            const readableLocation = locations[location];
             console.error(
-                e.message +
-                    ": " +
-                    locations[location] +
-                    " (total: " +
-                    nErrors +
-                    ")"
+                `${message}: ${readableLocation} (total: ${nErrors})`
             );
             if (nErrors >= maxErrors) {
-                throw new Error("Empty object returned for all locations");
+                throw new Error(E_NO_API_RES);
             }
         }
     }
-    if ("meal" in query)
-        // filter out duplicate entries from the list of MenuItems
-        return allMenus.filter(
-            (entry, index, self) =>
-                self.findIndex(
-                    otherEntry =>
-                        otherEntry.name === entry.name &&
-                        otherEntry.itemID === entry.itemID
-                ) === index
-        );
-    else return allMenus;
+    return "meal" in query
+        ? allMenus.filter(
+              (entry, index, self) =>
+                  index ===
+                  self.findIndex(
+                      otherEntry =>
+                          otherEntry.name === entry.name &&
+                          otherEntry.itemID === entry.itemID
+                  )
+          )
+        : allMenus;
 }

--- a/server/src/routers/MenusRouter/getMenuItemList.js
+++ b/server/src/routers/MenusRouter/getMenuItemList.js
@@ -18,7 +18,8 @@ export default function getMenuItemList(columns, data) {
             ? undefined
             : {
                   name: entry[columns.indexOf("MENUITEM")].replace("`", "'"),
-                  itemID: entry[columns.indexOf("MENUITEMID")]
+                  itemID: entry[columns.indexOf("MENUITEMID")],
+                  meal: entry[columns.indexOf("MEALNAME")]
               };
     });
     // filter out undefined and duplicate entries
@@ -30,7 +31,8 @@ export default function getMenuItemList(columns, data) {
                 self.findIndex(
                     otherEntry =>
                         otherEntry.name === entry.name &&
-                        otherEntry.itemID === entry.itemID
+                        otherEntry.itemID === entry.itemID &&
+                        otherEntry.meal === entry.meal
                 )
         );
     return filteredMenu.length ? filteredMenu : undefined;

--- a/server/src/routers/MenusRouter/getOneMenu.js
+++ b/server/src/routers/MenusRouter/getOneMenu.js
@@ -1,8 +1,8 @@
 import axios from "axios";
 
 import processMenu from "./processMenu";
-
-const MENUS_URI = "http://www.yaledining.org/fasttrack/menus.cfm?version=3";
+import queryBuilder from "../../util/queryBuilder";
+import { MENUS_URI } from "../../config/constants";
 
 /*
  *   getOneMenu(query)
@@ -17,7 +17,8 @@ const MENUS_URI = "http://www.yaledining.org/fasttrack/menus.cfm?version=3";
  *       an array of [MenuItem | Menus] objects, depending on whether the query object contains the meal key or not (respectively)
  */
 export default async function getOneMenu(query) {
-    const endpoint = MENUS_URI + "&location=" + query.location;
+    const location = query.location;
+    const endpoint = MENUS_URI + queryBuilder({ location });
     const response = await axios.get(endpoint);
     return processMenu(response.data, query);
 }

--- a/server/src/routers/MenusRouter/processMenu.js
+++ b/server/src/routers/MenusRouter/processMenu.js
@@ -1,6 +1,8 @@
 import getMenuItemList from "./getMenuItemList";
+
 import mealNames from "../../config/mealNames";
-import monthName from "../../config/monthName";
+import dateBuilder from "../../util/dateBuilder";
+import { E_NO_API_RES, E_BAD_MENU_REQ } from "../../config/constants";
 
 /*
  *   processMenu(data, query)
@@ -22,28 +24,15 @@ import monthName from "../../config/monthName";
 export default function processMenu(data, query) {
     // throw on bad response from Yale Dining
     if (!data || !data.DATA || !data.DATA.length || !data.DATA[0].length) {
-        throw new Error("Empty object returned from YaleDining API");
+        throw new Error(E_NO_API_RES);
     }
-    // get date for menus -- relies on the fact that server is on EST/EDT
-    const date = new Date();
-    const today =
-        monthName[date.getMonth()] +
-        ", " +
-        date.getDate() +
-        " " +
-        date.getFullYear() +
-        " 00:00:00";
-    const tomorrow =
-        monthName[date.getMonth()] +
-        ", " +
-        (date.getDate() + 1) +
-        " " +
-        date.getFullYear() +
-        " 00:00:00";
+    const today = dateBuilder(0);
+    const tomorrow = dateBuilder(1);
     // meal query -- return a list of MenuItem objects
     if ("meal" in query) {
+        const { meal } = query;
         const filteredData =
-            query.meal == "all"
+            meal == "all"
                 ? data.DATA.filter(
                       entry => entry[data.COLUMNS.indexOf("MENUDATE")] == today
                   )
@@ -51,11 +40,11 @@ export default function processMenu(data, query) {
                       entry =>
                           entry[data.COLUMNS.indexOf("MENUDATE")] == today &&
                           mealNames[entry[data.COLUMNS.indexOf("MEALNAME")]] ==
-                              query.meal
+                              meal
                   );
         const menuItemList = getMenuItemList(data.COLUMNS, filteredData);
         if (menuItemList == undefined) {
-            throw new Error("Invalid menu request");
+            throw new Error(E_BAD_MENU_REQ);
         } else {
             return menuItemList;
         }

--- a/server/src/util/dateBuilder.js
+++ b/server/src/util/dateBuilder.js
@@ -1,0 +1,14 @@
+import monthName from "../config/monthName";
+
+export default function dateBuilder(offset) {
+    // get date for menus -- relies on the fact that server is on EST/EDT
+    const currentDate = new Date();
+    const date =
+        monthName[currentDate.getMonth()] +
+        ", " +
+        (currentDate.getDate() + offset) +
+        " " +
+        currentDate.getFullYear() +
+        " 00:00:00";
+    return date;
+}

--- a/server/src/util/queryBuilder.js
+++ b/server/src/util/queryBuilder.js
@@ -1,0 +1,22 @@
+/** Builds a query string from the key-value pairs
+ * of an object.
+ *
+ * Example: {friends: 7, hello: "sir"}
+ * Returns "?friends=7&hello=sir"
+ */
+export default function queryBuilder(queryObject) {
+    // Return the empty string if no object is passed in
+    if (!queryObject) return "";
+    const keys = Object.keys(queryObject);
+    // Return the empty string if the object is empty
+    if (keys.length == 0) return "";
+    let queryString = "?";
+    let queryCount = 0;
+    for (let key of keys) {
+        if (queryCount > 0) queryString += "&";
+        const value = queryObject[key];
+        queryString = queryString + `${key}=${value}`;
+        queryCount++;
+    }
+    return queryString;
+}

--- a/server/tst/FavoritesRouter/addFavorite.test.js
+++ b/server/tst/FavoritesRouter/addFavorite.test.js
@@ -1,9 +1,14 @@
+import * as firebase from "firebase-admin";
+
 import addFavorite from "../../src/routers/FavoritesRouter/addFavorite";
 import firestore from "../../src/config/firebase/firebaseConfig";
 
 jest.mock("../../src/config/firebase/firebaseConfig");
+// jest.mock("firebase-admin");
 
 beforeEach(() => {
+    firebase.firestore.FieldValue = jest.fn();
+    firebase.firestore.FieldValue.arrayUnion = jest.fn();
     firestore.doc = jest.fn();
     firestore.doc.update = jest.fn();
     console.error = jest.fn();

--- a/server/tst/LocationsRouter/processLocations.test.js
+++ b/server/tst/LocationsRouter/processLocations.test.js
@@ -6,9 +6,9 @@ import locations from "../../src/config/locations";
 
 jest.mock("../../src/routers/LocationsRouter/getOneLocation");
 
-beforeEach(() => (console.warn = jest.fn()));
+beforeEach(() => (console.error = jest.fn()));
 afterEach(() => {
-    console.warn.mockClear();
+    console.error.mockClear();
     getOneLocation.mockClear();
 });
 
@@ -39,7 +39,7 @@ test("processLocations() -- normal function without location", async () => {
         processLocations(responses.locationResponse, {})
     ).resolves.toEqual(responses.allLocationsExpectedResponse);
     expect(getOneLocation).toHaveBeenCalledTimes(Object.keys(locations).length);
-    expect(console.warn).toHaveBeenCalledTimes(
+    expect(console.error).toHaveBeenCalledTimes(
         Object.keys(locations).length - 2
     );
 });
@@ -68,5 +68,5 @@ test("processLocations() -- throws on bad response from getOneLocation() without
         processLocations(responses.locationResponse, {})
     ).rejects.toThrow("Empty object returned from YaleDining API");
     expect(getOneLocation).toHaveBeenCalledTimes(Object.keys(locations).length);
-    expect(console.warn).toHaveBeenCalledTimes(Object.keys(locations).length);
+    expect(console.error).toHaveBeenCalledTimes(Object.keys(locations).length);
 });

--- a/server/tst/MenuItemsRouter/getMenuIdInfo.test.js
+++ b/server/tst/MenuItemsRouter/getMenuIdInfo.test.js
@@ -1,34 +1,50 @@
-import axios from 'axios';
+import axios from "axios";
 
-import getMenuIdInfo from '../../src/routers/MenuItemsRouter/getMenuIdInfo';
-import parseMenuItemData from '../../src/routers/MenuItemsRouter/parseMenuItemData';
-import * as responses from '../config/menuItemResponses';
+import getMenuIdInfo from "../../src/routers/MenuItemsRouter/getMenuIdInfo";
+import parseMenuItemData from "../../src/routers/MenuItemsRouter/parseMenuItemData";
+import * as responses from "../config/menuItemResponses";
+import { E_NO_API_RES } from "../../src/config/constants";
 
-jest.mock('axios');
-jest.mock('../../src/routers/MenuItemsRouter/parseMenuItemData');
+jest.mock("axios");
+jest.mock("../../src/routers/MenuItemsRouter/parseMenuItemData");
 
-
-test('getMenuIdInfo() -- normal function', async () => {
-	axios.get.mockImplementationOnce(() => Promise.resolve({"data": responses.nutritionWaffleData}));
-	axios.get.mockImplementationOnce(() => Promise.resolve({"data": responses.filterWaffleData}));
-	axios.get.mockImplementationOnce(() => Promise.resolve({"data": responses.ingredientWaffleData}));
-    parseMenuItemData.mockImplementationOnce(() => responses.menuItemDataResponse);
-    await expect(getMenuIdInfo(5908402)).resolves.toEqual(responses.menuItemDataResponse);
-    expect(parseMenuItemData).toHaveBeenCalledWith(responses.nutritionWaffleData,responses.filterWaffleData, responses.ingredientWaffleData);
+test("getMenuIdInfo() -- normal function", async () => {
+    axios.get.mockImplementationOnce(() =>
+        Promise.resolve({ data: responses.nutritionWaffleData })
+    );
+    axios.get.mockImplementationOnce(() =>
+        Promise.resolve({ data: responses.filterWaffleData })
+    );
+    axios.get.mockImplementationOnce(() =>
+        Promise.resolve({ data: responses.ingredientWaffleData })
+    );
+    parseMenuItemData.mockImplementationOnce(
+        () => responses.menuItemDataResponse
+    );
+    await expect(getMenuIdInfo(5908402)).resolves.toEqual(
+        responses.menuItemDataResponse
+    );
+    expect(parseMenuItemData).toHaveBeenCalledWith(
+        responses.nutritionWaffleData,
+        responses.filterWaffleData,
+        responses.ingredientWaffleData
+    );
 });
 
-test('getMenuIdInfo() -- bad response from axios', async () => {
+test("getMenuIdInfo() -- bad response from axios", async () => {
     axios.get.mockResolvedValue(undefined);
-    await expect(getMenuIdInfo(5908402)).rejects.toThrow('Error caught (getMenuIdInfo): 5908402');
+    await expect(getMenuIdInfo(5908402)).rejects.toThrow(E_NO_API_RES);
 });
 
-test('getMenuIdInfo() -- exception caught from axios', async () => {
+test("getMenuIdInfo() -- exception caught from axios", async () => {
     axios.get.mockImplementation(() => Promise.reject());
-    await expect(getMenuIdInfo(5908402)).rejects.toThrow('Error caught (getMenuIdInfo): 5908402');
+    await expect(getMenuIdInfo(5908402)).rejects.toThrow(E_NO_API_RES);
 });
 
-test('getMenuIdInfo() -- exception caught from getMenuIdInfo()', async () => {
-    axios.get.mockResolvedValue({ 'data': undefined });
-    parseMenuItemData.mockImplementationOnce(() => { throw new Error('Empty nutrition object returned from YaleDining API') });
-    await expect(getMenuIdInfo(5908402)).rejects.toThrow('Error caught (getMenuIdInfo): 5908402');
+test("getMenuIdInfo() -- exception caught from getMenuIdInfo()", async () => {
+    axios.get.mockResolvedValue({ data: undefined });
+    parseMenuItemData.mockImplementationOnce(() => {
+        throw new Error(E_NO_API_RES);
+    });
+    await expect(getMenuIdInfo(5908402)).rejects.toThrow(E_NO_API_RES);
 });

--- a/server/tst/MenuItemsRouter/parseMenuItemData.test.js
+++ b/server/tst/MenuItemsRouter/parseMenuItemData.test.js
@@ -1,23 +1,50 @@
-import parseMenuItemData from '../../src/routers/MenuItemsRouter/parseMenuItemData';
-import parseNutritionInfo from '../../src/routers/MenuItemsRouter/parseNutritionInfo';
-import * as responses from '../config/menuItemResponses';
+import parseMenuItemData from "../../src/routers/MenuItemsRouter/parseMenuItemData";
+import parseNutritionInfo from "../../src/routers/MenuItemsRouter/parseNutritionInfo";
+import * as responses from "../config/menuItemResponses";
+import { E_NO_API_RES } from "../../src/config/constants";
 
-jest.mock('../../src/routers/MenuItemsRouter/parseNutritionInfo');
+jest.mock("../../src/routers/MenuItemsRouter/parseNutritionInfo");
 
-test('parseMenuItemData() -- normal function', () => {
-    parseNutritionInfo.mockImplementationOnce(() => responses.nutritionWaffleResponse);
-    expect(parseMenuItemData(responses.nutritionWaffleData, responses.filterWaffleData, responses.ingredientWaffleData)).toEqual(responses.menuItemDataResponse);
+test("parseMenuItemData() -- normal function", () => {
+    parseNutritionInfo.mockImplementationOnce(
+        () => responses.nutritionWaffleResponse
+    );
+    expect(
+        parseMenuItemData(
+            responses.nutritionWaffleData,
+            responses.filterWaffleData,
+            responses.ingredientWaffleData
+        )
+    ).toEqual(responses.menuItemDataResponse);
     expect(parseNutritionInfo).toHaveBeenCalledWith(responses.nutritionWaffle);
 });
 
-test('parseMenuItemData() -- empty nutrition input', () => {
-	expect(() => parseMenuItemData({},responses.filterWaffleData, responses.ingredientWaffleData)).toThrow('Empty nutrition object returned from YaleDining API');
+test("parseMenuItemData() -- empty nutrition input", () => {
+    expect(() =>
+        parseMenuItemData(
+            {},
+            responses.filterWaffleData,
+            responses.ingredientWaffleData
+        )
+    ).toThrow(E_NO_API_RES);
 });
 
-test('parseMenuItemData() -- empty filter input', () => {
-	expect(() => parseMenuItemData(responses.nutritionWaffleData, {}, responses.ingredientWaffleData)).toThrow('Empty filter object returned from YaleDining API');
+test("parseMenuItemData() -- empty filter input", () => {
+    expect(() =>
+        parseMenuItemData(
+            responses.nutritionWaffleData,
+            {},
+            responses.ingredientWaffleData
+        )
+    ).toThrow(E_NO_API_RES);
 });
 
-test('parseMenuItemData() -- empty ingredient input', () => {
-	expect(() => parseMenuItemData(responses.nutritionWaffleData, responses.filterWaffleData, {})).toThrow('Empty ingredient object returned from YaleDining API');
+test("parseMenuItemData() -- empty ingredient input", () => {
+    expect(() =>
+        parseMenuItemData(
+            responses.nutritionWaffleData,
+            responses.filterWaffleData,
+            {}
+        )
+    ).toThrow(E_NO_API_RES);
 });

--- a/server/tst/MenusRouter/getAllMenus.test.js
+++ b/server/tst/MenusRouter/getAllMenus.test.js
@@ -2,6 +2,7 @@ import getAllMenus from "../../src/routers/MenusRouter/getAllMenus";
 import getOneMenu from "../../src/routers/MenusRouter/getOneMenu";
 import * as responses from "./responses";
 import locations from "../../src/config/locations";
+import { E_NO_API_RES } from "../../src/config/constants";
 
 jest.mock("../../src/routers/MenusRouter/getOneMenu");
 
@@ -18,9 +19,7 @@ test("getAllMenus() -- normal function with meal query", async () => {
             case "5":
                 return responses.morseDinnerMenu;
             default:
-                throw new Error(
-                    "Empty object returned for: " + locations[query.location]
-                );
+                throw new Error(E_NO_API_RES);
         }
     });
     await expect(getAllMenus({ meal: "dinner" })).resolves.toEqual(
@@ -41,9 +40,7 @@ test("getAllMenus() -- normal function without meal query", async () => {
             case "5":
                 return responses.morseMenu;
             default:
-                throw new Error(
-                    "Empty object returned for: " + locations[query.location]
-                );
+                throw new Error(E_NO_API_RES);
         }
     });
     await expect(getAllMenus({})).resolves.toEqual(
@@ -64,9 +61,7 @@ test("getAllMenus() -- normal function with meal query with duplicates", async (
             case "5":
                 return responses.morseDinnerMenuDuplicate;
             default:
-                throw new Error(
-                    "Empty object returned for: " + locations[query.location]
-                );
+                throw new Error(E_NO_API_RES);
         }
     });
     await expect(getAllMenus({ meal: "dinner" })).resolves.toEqual(
@@ -79,12 +74,8 @@ test("getAllMenus() -- normal function with meal query with duplicates", async (
 
 test("getAllMenus() -- bad response from all dinining halls", async () => {
     getOneMenu.mockImplementation(() => {
-        throw new Error(
-            "Empty object returned for: " + locations[query.location]
-        );
+        throw new Error(E_NO_API_RES);
     });
-    await expect(getAllMenus({})).rejects.toThrow(
-        "Empty object returned for all locations"
-    );
+    await expect(getAllMenus({})).rejects.toThrow(E_NO_API_RES);
     expect(console.error).toHaveBeenCalledTimes(Object.keys(locations).length);
 });

--- a/server/tst/MenusRouter/getAllMenus.test.js
+++ b/server/tst/MenusRouter/getAllMenus.test.js
@@ -5,8 +5,8 @@ import locations from "../../src/config/locations";
 
 jest.mock("../../src/routers/MenusRouter/getOneMenu");
 
-beforeEach(() => (console.warn = jest.fn()));
-afterEach(() => console.warn.mockClear());
+beforeEach(() => (console.error = jest.fn()));
+afterEach(() => console.error.mockClear());
 
 test("getAllMenus() -- normal function with meal query", async () => {
     getOneMenu.mockImplementation(query => {
@@ -26,7 +26,7 @@ test("getAllMenus() -- normal function with meal query", async () => {
     await expect(getAllMenus({ meal: "dinner" })).resolves.toEqual(
         responses.multiDinnerMenu
     );
-    expect(console.warn).toHaveBeenCalledTimes(
+    expect(console.error).toHaveBeenCalledTimes(
         Object.keys(locations).length - 3
     );
 });
@@ -49,7 +49,7 @@ test("getAllMenus() -- normal function without meal query", async () => {
     await expect(getAllMenus({})).resolves.toEqual(
         responses.multiMenuExpectedResponse
     );
-    expect(console.warn).toHaveBeenCalledTimes(
+    expect(console.error).toHaveBeenCalledTimes(
         Object.keys(locations).length - 3
     );
 });
@@ -72,7 +72,7 @@ test("getAllMenus() -- normal function with meal query with duplicates", async (
     await expect(getAllMenus({ meal: "dinner" })).resolves.toEqual(
         responses.multiDinnerMenu
     );
-    expect(console.warn).toHaveBeenCalledTimes(
+    expect(console.error).toHaveBeenCalledTimes(
         Object.keys(locations).length - 3
     );
 });
@@ -86,5 +86,5 @@ test("getAllMenus() -- bad response from all dinining halls", async () => {
     await expect(getAllMenus({})).rejects.toThrow(
         "Empty object returned for all locations"
     );
-    expect(console.warn).toHaveBeenCalledTimes(Object.keys(locations).length);
+    expect(console.error).toHaveBeenCalledTimes(Object.keys(locations).length);
 });

--- a/server/tst/MenusRouter/responses.js
+++ b/server/tst/MenusRouter/responses.js
@@ -89,25 +89,28 @@ export const singleMenuDataWithDuplicates = [
 ];
 
 export const contBreakfastMenu = [
-    { itemID: 3952458.0, name: "Cage-Free Hard-Boiled Eggs" }
+    {
+        itemID: 3952458,
+        meal: "Cont. Breakfast",
+        name: "Cage-Free Hard-Boiled Eggs"
+    }
 ];
 export const hotBreakfastMenu = [
-    { itemID: 4822535, name: "Multigrain Pancakes" }
+    { itemID: 4822535, meal: "Hot Breakfast", name: "Multigrain Pancakes" }
 ];
 export const brunchMenu = [
-    { itemID: 3871561, name: "Greek Salad with Arugula" }
+    { itemID: 3871561, meal: "Brunch", name: "Greek Salad with Arugula" }
 ];
 export const lunchMenu = [
-    { itemID: 4883833, name: "Farro Salad with Raisins" }
+    { itemID: 4883833, meal: "Lunch", name: "Farro Salad with Raisins" }
 ];
 export const dinnerMenu = [
-    { itemID: 3579035, name: "Naples Style Beef Chuck" }
+    { itemID: 3579035, meal: "Dinner", name: "Naples Style Beef Chuck" }
 ];
-export const allMealsMenu = [
-    { itemID: 4822535, name: "Multigrain Pancakes" },
-    { itemID: 4883833, name: "Farro Salad with Raisins" },
-    { itemID: 3579035, name: "Naples Style Beef Chuck" }
+export const dessertMenu = [
+    { itemID: 5366094, meal: "Dinner", name: "Lemon Raspberry Sheet Cake" }
 ];
+export const allMealsMenu = [hotBreakfastMenu[0], lunchMenu[0], dinnerMenu[0]];
 
 export const emptyExpectedResponse = [
     {
@@ -136,8 +139,8 @@ export const morseMenu = [
             brunch: undefined,
             contBreakfast: undefined,
             dinner: undefined,
-            hotBreakfast: [{ itemID: 4822535, name: "Multigrain Pancakes" }],
-            lunch: [{ itemID: 4883833, name: "Farro Salad with Raisins" }]
+            hotBreakfast: hotBreakfastMenu,
+            lunch: lunchMenu
         },
         tomorrow: {
             brunch: undefined,
@@ -149,9 +152,7 @@ export const morseMenu = [
     }
 ];
 export const morseDinnerMenu = [];
-export const morseDinnerMenuDuplicate = [
-    { itemID: 3579035, name: "Naples Style Beef Chuck" }
-];
+export const morseDinnerMenuDuplicate = dinnerMenu;
 
 export const hopperMenu = [
     {
@@ -159,9 +160,9 @@ export const hopperMenu = [
         today: {
             brunch: undefined,
             contBreakfast: undefined,
-            dinner: [{ itemID: 3579035, name: "Naples Style Beef Chuck" }],
+            dinner: dinnerMenu,
             hotBreakfast: undefined,
-            lunch: [{ itemID: 4883833, name: "Farro Salad with Raisins" }]
+            lunch: lunchMenu
         },
         tomorrow: {
             brunch: undefined,
@@ -172,9 +173,7 @@ export const hopperMenu = [
         }
     }
 ];
-export const hopperDinnerMenu = [
-    { itemID: 3579035, name: "Naples Style Beef Chuck" }
-];
+export const hopperDinnerMenu = dinnerMenu;
 
 export const davenportMenu = [
     {
@@ -182,7 +181,7 @@ export const davenportMenu = [
         today: {
             brunch: undefined,
             contBreakfast: undefined,
-            dinner: [{ itemID: 5366094, name: "Lemon Raspberry Sheet Cake" }],
+            dinner: dessertMenu,
             hotBreakfast: undefined,
             lunch: undefined
         },
@@ -195,21 +194,19 @@ export const davenportMenu = [
         }
     }
 ];
-export const davenportDinnerMenu = [
-    { itemID: 5366094, name: "Lemon Raspberry Sheet Cake" }
-];
+export const davenportDinnerMenu = dessertMenu;
 
 /* Expected Outputs */
 
 export const singleMenuDataExpectedResponse = [
-    { itemID: 4822535, name: "Multigrain Pancakes" },
-    { itemID: 4883833, name: "Farro Salad with Raisins" },
-    { itemID: 3579035, name: "Naples Style Beef Chuck" }
+    hotBreakfastMenu[0],
+    lunchMenu[0],
+    dinnerMenu[0]
 ];
 
 export const singleMenuDataWithEmptyExpectedResponse = [
-    { itemID: 4822535, name: "Multigrain Pancakes" },
-    { itemID: 3579035, name: "Naples Style Beef Chuck" }
+    hotBreakfastMenu[0],
+    dinnerMenu[0]
 ];
 
 export const fullMenuExpectedResponse = [
@@ -218,9 +215,9 @@ export const fullMenuExpectedResponse = [
         today: {
             brunch: undefined,
             contBreakfast: undefined,
-            dinner: [{ itemID: 3579035, name: "Naples Style Beef Chuck" }],
-            hotBreakfast: [{ itemID: 4822535, name: "Multigrain Pancakes" }],
-            lunch: [{ itemID: 4883833, name: "Farro Salad with Raisins" }]
+            dinner: dinnerMenu,
+            hotBreakfast: hotBreakfastMenu,
+            lunch: lunchMenu
         },
         tomorrow: {
             brunch: undefined,
@@ -238,9 +235,9 @@ export const multiMenuExpectedResponse = [
         today: {
             brunch: undefined,
             contBreakfast: undefined,
-            dinner: [{ itemID: 3579035, name: "Naples Style Beef Chuck" }],
+            dinner: dinnerMenu,
             hotBreakfast: undefined,
-            lunch: [{ itemID: 4883833, name: "Farro Salad with Raisins" }]
+            lunch: lunchMenu
         },
         tomorrow: {
             brunch: undefined,
@@ -255,7 +252,7 @@ export const multiMenuExpectedResponse = [
         today: {
             brunch: undefined,
             contBreakfast: undefined,
-            dinner: [{ itemID: 5366094, name: "Lemon Raspberry Sheet Cake" }],
+            dinner: dessertMenu,
             hotBreakfast: undefined,
             lunch: undefined
         },
@@ -273,8 +270,8 @@ export const multiMenuExpectedResponse = [
             brunch: undefined,
             contBreakfast: undefined,
             dinner: undefined,
-            hotBreakfast: [{ itemID: 4822535, name: "Multigrain Pancakes" }],
-            lunch: [{ itemID: 4883833, name: "Farro Salad with Raisins" }]
+            hotBreakfast: hotBreakfastMenu,
+            lunch: lunchMenu
         },
         tomorrow: {
             brunch: undefined,
@@ -286,7 +283,4 @@ export const multiMenuExpectedResponse = [
     }
 ];
 
-export const multiDinnerMenu = [
-    { itemID: 3579035, name: "Naples Style Beef Chuck" },
-    { itemID: 5366094, name: "Lemon Raspberry Sheet Cake" }
-];
+export const multiDinnerMenu = [dinnerMenu[0], dessertMenu[0]];


### PR DESCRIPTION
## Summary
This is the first half of implementing the notification service for Dining*v2. It first gets a list of menu items being served on the current day. Then, it loops through the Firestore document `favorites/menuItems` which maps menu item IDs to Expo tokens of users who have favorited that item. It collects all such tokens into an object which can then be sent to the Expo API to push the notifications to the devices.

~Currently, the notification is very limited: "[item] is being served today!" -- I'm working on a follow up which should allow for more detailed information to be passed.~

I'm a wizard ^
## Usage
You don't use this. It runs automatically every day at 7am EST.
## Testing
I temporarily set the callback function as the route handler for a `GET` request and verified that it works as intended. I still have to learn how to mock Firebase calls with Jest (I also broke the tests in `Favorites Router`).

I think I also broke more tests with the most recent commit, which adds extra information to the notifications by expanding the existing API.