### PR TITLE
server/zm+sk-favoritesGetRoute

### DIFF
--- a/server/src/config/constants.js
+++ b/server/src/config/constants.js
@@ -8,7 +8,8 @@ export const E_NO_API_RES = "Empty object returned from YaleDining API";
 
 export const E_BAD_LOC_REQ = "Invalid location request";
 export const E_BAD_MENU_REQ = "Invalid menu request";
-export const E_BAD_FAVE_REQ = "Push token and item ID are required";
+export const E_BAD_FAVE_POST_REQ = "Push token and item ID are required";
+export const E_BAD_FAVE_GET_REQ = "Expo token is required";
 
 export const E_DB_READ = "Error getting document: ";
 export const E_DB_WRITE = "Could not write document: ";

--- a/server/src/routers/FavoritesRouter/FavoritesRouter.js
+++ b/server/src/routers/FavoritesRouter/FavoritesRouter.js
@@ -1,11 +1,21 @@
 import express from "express";
 
+import getFavorites from "./getFavorites";
 import addFavorite from "./addFavorite";
 import removeFavorite from "./removeFavorite";
 
 const router = express.Router();
 
 router
+    .get("/", async (req, res) => {
+        try {
+            const favorites = await getFavorites(`ExponentPushToken[${req.query.token}]`);
+            res.send(favorites);
+        } catch (e) {
+            console.error(e);
+            res.sendStatus(500);
+        }
+    })
     .post("/", async (req, res) => {
         try {
             await addFavorite(req.body.token, req.body.menuitemid);

--- a/server/src/routers/FavoritesRouter/addFavorite.js
+++ b/server/src/routers/FavoritesRouter/addFavorite.js
@@ -1,11 +1,11 @@
 import * as firebase from "firebase-admin";
 import firestore from "../../config/firebase/firebaseConfig";
 
-import { E_BAD_FAVE_REQ, E_DB_WRITE } from "../../config/constants";
+import { E_BAD_FAVE_POST_REQ, E_DB_WRITE } from "../../config/constants";
 
 export default async function addFavorite(token, menuItemID) {
     if (!token || !menuItemID) {
-        throw new Error(E_BAD_FAVE_REQ);
+        throw new Error(E_BAD_FAVE_POST_REQ);
     }
     try {
         await firestore.doc("favorites/menuItems").update({

--- a/server/src/routers/FavoritesRouter/getFavorites.js
+++ b/server/src/routers/FavoritesRouter/getFavorites.js
@@ -1,0 +1,25 @@
+import firestore from "../../config/firebase/firebaseConfig";
+
+import { E_DB_READ, E_DB_NOENT, E_BAD_FAVE_GET_REQ } from "../../config/constants";
+
+export default async function getFavorites(token) {
+    let usersDoc = undefined;
+    try {
+        usersDoc = await firestore.doc("favorites/users").get();
+    } catch (e) {
+        throw new Error(E_DB_READ + e);
+    }
+    if (!usersDoc.exists) {
+        throw new Error(E_DB_NOENT + "favorites/users");
+    } else if (!token) {
+        throw new Error(E_BAD_FAVE_GET_REQ);
+    }
+
+    var menuItems = {};
+    usersDoc.data()[token]
+        ? usersDoc.data()[token].forEach(menuItem => menuItems[menuItem] = true)
+        : await firestore
+            .doc("favorites/users")
+            .update({ [token]: [] });
+    return menuItems;
+}

--- a/server/src/routers/FavoritesRouter/removeFavorite.js
+++ b/server/src/routers/FavoritesRouter/removeFavorite.js
@@ -4,7 +4,7 @@ import { E_BAD_FAVE_REQ, E_DB_WRITE } from "../../config/constants";
 
 export default async function removeFavorite(token, menuItemID) {
     if (!token || !menuItemID) {
-        throw new Error(E_BAD_FAVE_REQ);
+        throw new Error(E_BAD_FAVE_POST_REQ);
     }
     try {
         await firestore.doc("favorites/menuItems").update({


### PR DESCRIPTION
## Summary

This provides a way for the front end to get information about a user's favorites so that the initial Redux state in the Menus view can be set appropriately. To set the initial state, the front end will need to call `/api/menus` _and_ `/api/favorites`. For each item in the response from `menus`, the front end will check to see if it is a member of the response from `favorites`, and if so, it will initialize its favorite property accordingly.

## Usage

Send a `GET` request sent to `/api/favorites` with the query `token=[ExpoToken]` where `ExpoToken` is the _string only_ of the device's expo token (use a regex to pick it out between the square brackets). E.g.` ExponentPushToken[12345] -> 12345`

Returns an object containing the user's favorite `menuitemids` as keys:
```
{
    [menuItem1]: true, 
    [menuItem2]: true, 
    ...
}
```

## Testing
Coming soon...