### PR TITLE
server/zm-getOneLocationLog

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3769,6 +3769,11 @@
         }
       }
     },
+    "fuse.js": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.4.tgz",
+      "integrity": "sha512-pyLQo/1oR5Ywf+a/tY8z4JygnIglmRxVUOiyFAbd11o9keUDpUJSMGRWJngcnkURj30kDHPmhoKY8ChJiz3EpQ=="
+    },
     "gauge": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",

--- a/server/Procfile
+++ b/server/Procfile
@@ -1,0 +1,1 @@
+web: node ./lib/index

--- a/server/src/routers/LocationsRouter/getOneLocation.js
+++ b/server/src/routers/LocationsRouter/getOneLocation.js
@@ -8,10 +8,18 @@ export default async function getOneLocation(data, query) {
     );
     if (location.length) {
         const entry = location[0];
+        let todayHours = undefined;
+        let tomorrowHours = undefined;
+        try {
+            todayHours = await getHours(query.location, 0);
+            tomorrowHours = await getHours(query.location, 1);
+        } catch (e) {
+            console.error(e);
+        }
         return {
             name: entry[data.COLUMNS.indexOf("DININGLOCATIONNAME")],
-            todayHours: await getHours(query.location, 0),
-            tomorrowHours: await getHours(query.location, 1),
+            todayHours,
+            tomorrowHours,
             isOpen: parseFloat(entry[data.COLUMNS.indexOf("ISCLOSED")])
                 ? false
                 : true,

--- a/server/tst/LocationsRouter/getOneLocation.test.js
+++ b/server/tst/LocationsRouter/getOneLocation.test.js
@@ -1,9 +1,11 @@
 import getOneLocation from "../../src/routers/LocationsRouter/getOneLocation";
 import getHours from "../../src/routers/LocationsRouter/getHours";
 import * as responses from "./responses";
+import { E_BAD_LOC_REQ, E_NO_API_RES } from "../../src/config/constants";
 
 jest.mock("../../src/routers/LocationsRouter/getHours");
 
+beforeAll(() => (console.error = jest.fn()));
 beforeEach(() => getHours.mockClear());
 
 test("getOneLocation() -- normal function", async () => {
@@ -27,14 +29,15 @@ test("getOneLocation() -- normal function", async () => {
 test("getOneLocation() -- throws on invalid location", async () => {
     await expect(
         getOneLocation(responses.locationResponse, { location: 999 })
-    ).rejects.toThrow("Invalid location request");
+    ).rejects.toThrow(E_BAD_LOC_REQ);
 });
 
-test("getOneLocation() -- throws when getHours() throws", async () => {
+test("getOneLocation() -- logs when getHours() throws", async () => {
     getHours.mockImplementationOnce(() => {
-        throw new Error("Empty object returned from YaleDining API");
+        throw new Error(E_NO_API_RES);
     });
     await expect(
         getOneLocation(responses.locationResponse, { location: 5 })
-    ).rejects.toThrow("Empty object returned from YaleDining API");
+    ).resolves.toEqual(responses.morseExpectedResponseEmpty);
+    expect(console.error).toHaveBeenCalled();
 });

--- a/server/tst/LocationsRouter/responses.js
+++ b/server/tst/LocationsRouter/responses.js
@@ -640,6 +640,15 @@ export const stilesExpectedResponse = {
     geolocation: [41.312492, -72.930647]
 };
 
+export const morseExpectedResponseEmpty = {
+    name: "Morse",
+    todayHours: undefined,
+    tomorrowHours: undefined,
+    isOpen: false,
+    busyness: 0,
+    geolocation: [41.312532, -72.930352]
+};
+
 export const allLocationsExpectedResponse = {
     Morse: morseExpectedResponse,
     Stiles: stilesExpectedResponse


### PR DESCRIPTION
## Updates
The `api/locations` route no longer throws on an empty response from Yale Dining, instead it logs the error and returns the constant information.

I also added a Procfile so we don't have to create it each time we deploy to Heroku.

Please suggest any other QoL changes and I'll make them on this PR.