### PR TITLE
server/zm-favoritesTokenOnly

### DIFF
--- a/server/src/config/constants.js
+++ b/server/src/config/constants.js
@@ -1,3 +1,5 @@
+export const YD_VERSION = 3;
+
 export const LOCATIONS_URI = "http://www.yaledining.org/fasttrack/locations.cfm";
 export const MENUS_URI = "http://www.yaledining.org/fasttrack/menus.cfm";
 export const NUTRITION_URI = "http://www.yaledining.org/fasttrack/menuitem-nutrition.cfm";

--- a/server/src/notifications/getMenuItemsToday.js
+++ b/server/src/notifications/getMenuItemsToday.js
@@ -5,13 +5,13 @@ import getMenuItemList from "../routers/MenusRouter/getMenuItemList";
 import locations from "../config/locations";
 import queryBuilder from "../util/queryBuilder";
 import dateBuilder from "../util/dateBuilder";
-import { MENUS_URI } from "../config/constants";
+import { MENUS_URI, YD_VERSION } from "../config/constants";
 
 export default async function getMenuItemsToday() {
     const today = dateBuilder(0);
     var completeMenuItemList = [];
     for (let location in locations) {
-        const endpoint = MENUS_URI + queryBuilder({ version: 3, location });
+        const endpoint = MENUS_URI + queryBuilder({ version: YD_VERSION, location });
         const response = await axios.get(endpoint);
         const filteredData = response.data.DATA.filter(
             entry => entry[response.data.COLUMNS.indexOf("MENUDATE")] == today

--- a/server/src/routers/FavoritesRouter/FavoritesRouter.js
+++ b/server/src/routers/FavoritesRouter/FavoritesRouter.js
@@ -10,10 +10,10 @@ router
     .get("/", async (req, res) => {
         try {
             const favorites = await getFavorites(req.query.token);
-            res.send(favorites);
+            res.send(favorites).status(200);
         } catch (e) {
             console.error(e);
-            res.sendStatus(500);
+            res.send(e).status(500);
         }
     })
     .post("/", async (req, res) => {
@@ -22,7 +22,7 @@ router
             res.sendStatus(200);
         } catch (e) {
             console.error(e);
-            res.sendStatus(500);
+            res.send(e).status(500);
         }
     })
     .post("/delete", async (req, res) => {
@@ -31,7 +31,7 @@ router
             res.sendStatus(200);
         } catch (e) {
             console.error(e);
-            res.sendStatus(500);
+            res.send(e).status(500);
         }
     });
 

--- a/server/src/routers/FavoritesRouter/FavoritesRouter.js
+++ b/server/src/routers/FavoritesRouter/FavoritesRouter.js
@@ -9,7 +9,7 @@ const router = express.Router();
 router
     .get("/", async (req, res) => {
         try {
-            const favorites = await getFavorites(`ExponentPushToken[${req.query.token}]`);
+            const favorites = await getFavorites(req.query.token);
             res.send(favorites);
         } catch (e) {
             console.error(e);

--- a/server/src/routers/FavoritesRouter/addFavorite.js
+++ b/server/src/routers/FavoritesRouter/addFavorite.js
@@ -7,9 +7,10 @@ export default async function addFavorite(token, menuItemID) {
     if (!token || !menuItemID) {
         throw new Error(E_BAD_FAVE_POST_REQ);
     }
+    const expoToken = `ExponentPushToken[${token}]`;
     try {
         await firestore.doc("favorites/menuItems").update({
-            [menuItemID]: firebase.firestore.FieldValue.arrayUnion(token)
+            [menuItemID]: firebase.firestore.FieldValue.arrayUnion(expoToken)
         });
         await firestore.doc("favorites/users").update({
             [token]: firebase.firestore.FieldValue.arrayUnion(menuItemID)

--- a/server/src/routers/FavoritesRouter/getFavorites.js
+++ b/server/src/routers/FavoritesRouter/getFavorites.js
@@ -1,6 +1,10 @@
 import firestore from "../../config/firebase/firebaseConfig";
 
-import { E_DB_READ, E_DB_NOENT, E_BAD_FAVE_GET_REQ } from "../../config/constants";
+import {
+    E_DB_READ,
+    E_DB_NOENT,
+    E_BAD_FAVE_GET_REQ
+} from "../../config/constants";
 
 export default async function getFavorites(token) {
     let usersDoc = undefined;
@@ -14,12 +18,12 @@ export default async function getFavorites(token) {
     } else if (!token) {
         throw new Error(E_BAD_FAVE_GET_REQ);
     }
-
+    const expoToken = `ExponentPushToken[${token}]`;
     var menuItems = {};
-    usersDoc.data()[token]
-        ? usersDoc.data()[token].forEach(menuItem => menuItems[menuItem] = true)
-        : await firestore
-            .doc("favorites/users")
-            .update({ [token]: [] });
+    usersDoc.data()[expoToken]
+        ? usersDoc
+              .data()
+              [expoToken].forEach(menuItem => (menuItems[menuItem] = true))
+        : await firestore.doc("favorites/users").update({ [expoToken]: [] });
     return menuItems;
 }

--- a/server/src/routers/FavoritesRouter/getFavorites.js
+++ b/server/src/routers/FavoritesRouter/getFavorites.js
@@ -1,22 +1,18 @@
 import firestore from "../../config/firebase/firebaseConfig";
 
-import {
-    E_DB_READ,
-    E_DB_NOENT,
-    E_BAD_FAVE_GET_REQ
-} from "../../config/constants";
+import * as constants from "../../config/constants";
 
 export default async function getFavorites(token) {
     let usersDoc = undefined;
     try {
         usersDoc = await firestore.doc("favorites/users").get();
     } catch (e) {
-        throw new Error(E_DB_READ + e);
+        throw new Error(constants.E_DB_READ + e);
     }
     if (!usersDoc.exists) {
-        throw new Error(E_DB_NOENT + "favorites/users");
+        throw new Error(constants.E_DB_NOENT + "favorites/users");
     } else if (!token) {
-        throw new Error(E_BAD_FAVE_GET_REQ);
+        throw new Error(constants.E_BAD_FAVE_GET_REQ);
     }
     const expoToken = `ExponentPushToken[${token}]`;
     var menuItems = {};

--- a/server/src/routers/FavoritesRouter/getFavorites.js
+++ b/server/src/routers/FavoritesRouter/getFavorites.js
@@ -17,9 +17,7 @@ export default async function getFavorites(token) {
     const expoToken = `ExponentPushToken[${token}]`;
     var menuItems = {};
     usersDoc.data()[expoToken]
-        ? usersDoc
-              .data()
-              [expoToken].forEach(menuItem => (menuItems[menuItem] = true))
+        ? usersDoc.data()[expoToken].forEach(item => (menuItems[item] = true))
         : await firestore.doc("favorites/users").update({ [expoToken]: [] });
     return menuItems;
 }

--- a/server/src/routers/FavoritesRouter/removeFavorite.js
+++ b/server/src/routers/FavoritesRouter/removeFavorite.js
@@ -1,14 +1,16 @@
 import * as firebase from "firebase-admin";
 import firestore from "../../config/firebase/firebaseConfig";
-import { E_BAD_FAVE_REQ, E_DB_WRITE } from "../../config/constants";
+
+import { E_BAD_FAVE_POST_REQ, E_DB_WRITE } from "../../config/constants";
 
 export default async function removeFavorite(token, menuItemID) {
     if (!token || !menuItemID) {
         throw new Error(E_BAD_FAVE_POST_REQ);
     }
+    const expoToken = `ExponentPushToken[${token}]`;
     try {
         await firestore.doc("favorites/menuItems").update({
-            [menuItemID]: firebase.firestore.FieldValue.arrayRemove(token)
+            [menuItemID]: firebase.firestore.FieldValue.arrayRemove(expoToken)
         });
         await firestore.doc("favorites/users").update({
             [token]: firebase.firestore.FieldValue.arrayRemove(menuItemID)

--- a/server/src/routers/LocationsRouter/LocationsRouter.js
+++ b/server/src/routers/LocationsRouter/LocationsRouter.js
@@ -9,13 +9,13 @@ const router = express.Router();
 router.get("/", async (req, res) => {
     try {
         const location = await getLocations(req.query);
-        res.send(location);
+        res.send(location).status(200);
     } catch (e) {
         console.error(e);
         if (e.message == E_BAD_LOC_REQ) {
-            res.sendStatus(400);
+            res.send(e).status(400);
         } else {
-            res.sendStatus(500);
+            res.send(e).status(500);
         }
     }
 });

--- a/server/src/routers/LocationsRouter/getHours.js
+++ b/server/src/routers/LocationsRouter/getHours.js
@@ -3,10 +3,10 @@ import axios from "axios";
 import mealNames from "../../config/mealNames";
 import queryBuilder from "../../util/queryBuilder";
 import dateBuilder from "../../util/dateBuilder";
-import { MENUS_URI, E_NO_API_RES } from "../../config/constants";
+import { MENUS_URI, E_NO_API_RES, YD_VERSION } from "../../config/constants";
 
 export default async function getHours(location, offset) {
-    const endpoint = MENUS_URI + queryBuilder({ version: 3, location });
+    const endpoint = MENUS_URI + queryBuilder({ version: YD_VERSION, location });
     const response = await axios.get(endpoint);
     const data = response.data;
     // throw on bad response from Yale Dining
@@ -24,15 +24,15 @@ export default async function getHours(location, offset) {
         );
         locationHours[mealNames[mealName]] = mealFilteredData.length
             ? {
-                  // all items have the same opening/closing time
-                  openingTime:
-                      mealFilteredData[0][data.COLUMNS.indexOf("MEALOPENS")],
-                  closingTime:
-                      mealFilteredData[0][data.COLUMNS.indexOf("MEALCLOSES")],
-                  transferTime: undefined
-                  // TODO: Hardcode in transfer times in ../../config/DiningHallHours
-                  // diningHallHours[locations[location]][mealNames[mealName]].transferTime
-              }
+                // all items have the same opening/closing time
+                openingTime:
+                    mealFilteredData[0][data.COLUMNS.indexOf("MEALOPENS")],
+                closingTime:
+                    mealFilteredData[0][data.COLUMNS.indexOf("MEALCLOSES")],
+                transferTime: undefined
+                // TODO: Hardcode in transfer times in ../../config/DiningHallHours
+                // diningHallHours[locations[location]][mealNames[mealName]].transferTime
+            }
             : undefined;
     }
     return locationHours;

--- a/server/src/routers/LocationsRouter/getLocations.js
+++ b/server/src/routers/LocationsRouter/getLocations.js
@@ -2,10 +2,10 @@ import axios from "axios";
 
 import processLocations from "./processLocations";
 import queryBuilder from "../../util/queryBuilder";
-import { LOCATIONS_URI } from "../../config/constants";
+import { LOCATIONS_URI, YD_VERSION } from "../../config/constants";
 
 export default async function getLocations(query) {
-    const response = await axios.get(LOCATIONS_URI + queryBuilder({ version: 3}));
+    const response = await axios.get(LOCATIONS_URI + queryBuilder({ version: YD_VERSION }));
     const locations = await processLocations(response.data, query);
     return locations;
 }

--- a/server/src/routers/MenuItemsRouter/MenuItemsRouter.js
+++ b/server/src/routers/MenuItemsRouter/MenuItemsRouter.js
@@ -11,10 +11,10 @@ router.get("/", async (req, res) => {
     } else {
         try {
             const menu = await getMenuIdInfo(req.query.menuitemid);
-            res.send(menu);
+            res.send(menu).status(200);
         } catch (e) {
             console.error(e);
-            res.sendStatus(500);
+            res.send(e).status(500);
         }
     }
 });

--- a/server/src/routers/MenuItemsRouter/getMenuIdInfo.js
+++ b/server/src/routers/MenuItemsRouter/getMenuIdInfo.js
@@ -3,12 +3,7 @@ import axios from "axios";
 import parseMenuItemData from "./parseMenuItemData";
 
 import queryBuilder from "../../util/queryBuilder";
-import {
-    NUTRITION_URI,
-    FILTERS_URI,
-    INGREDIENTS_URI,
-    E_NO_API_RES
-} from "../../config/constants";
+import * as constants from "../../config/constants";
 
 /**
  * Gets nutrition, filters (allergans, etc), and ingredients data from dining api
@@ -22,11 +17,14 @@ import {
 
 export default async function getMenuIdInfo(menuitemid) {
     const nutritionEndpoint =
-        NUTRITION_URI + queryBuilder({ version: 3, MENUITEMID: menuitemid });
+        constants.NUTRITION_URI +
+        queryBuilder({ version: 3, MENUITEMID: menuitemid });
     const filterEndpoint =
-        FILTERS_URI + queryBuilder({ version: 3, MENUITEMID: menuitemid });
+        constants.FILTERS_URI +
+        queryBuilder({ version: 3, MENUITEMID: menuitemid });
     const ingredientsEndpoint =
-        INGREDIENTS_URI + queryBuilder({ version: 3, MENUITEMID: menuitemid });
+        constants.INGREDIENTS_URI +
+        queryBuilder({ version: 3, MENUITEMID: menuitemid });
     try {
         const nutritionResponse = await axios.get(nutritionEndpoint);
         const filterResponse = await axios.get(filterEndpoint);
@@ -38,6 +36,6 @@ export default async function getMenuIdInfo(menuitemid) {
         );
         return menu;
     } catch (e) {
-        throw new Error(E_NO_API_RES);
+        throw new Error(constants.E_NO_API_RES);
     }
 }

--- a/server/src/routers/MenuItemsRouter/getMenuIdInfo.js
+++ b/server/src/routers/MenuItemsRouter/getMenuIdInfo.js
@@ -18,13 +18,13 @@ import * as constants from "../../config/constants";
 export default async function getMenuIdInfo(menuitemid) {
     const nutritionEndpoint =
         constants.NUTRITION_URI +
-        queryBuilder({ version: 3, MENUITEMID: menuitemid });
+        queryBuilder({ version: constants.YD_VERSION, MENUITEMID: menuitemid });
     const filterEndpoint =
         constants.FILTERS_URI +
-        queryBuilder({ version: 3, MENUITEMID: menuitemid });
+        queryBuilder({ version: constants.YD_VERSION, MENUITEMID: menuitemid });
     const ingredientsEndpoint =
         constants.INGREDIENTS_URI +
-        queryBuilder({ version: 3, MENUITEMID: menuitemid });
+        queryBuilder({ version: constants.YD_VERSION, MENUITEMID: menuitemid });
     try {
         const nutritionResponse = await axios.get(nutritionEndpoint);
         const filterResponse = await axios.get(filterEndpoint);

--- a/server/src/routers/MenusRouter/MenusRouter.js
+++ b/server/src/routers/MenusRouter/MenusRouter.js
@@ -9,13 +9,13 @@ const router = express.Router();
 router.get("/", async (req, res) => {
     try {
         const menus = await getMenus(req.query);
-        res.send(menus);
+        res.send(menus).status(200);
     } catch (e) {
         console.error(e);
         if (e.message == E_BAD_MENU_REQ) {
-            res.sendStatus(400);
+            res.send(e).status(400);
         } else {
-            res.sendStatus(500);
+            res.send(e).status(500);
         }
     }
 });

--- a/server/src/routers/MenusRouter/getOneMenu.js
+++ b/server/src/routers/MenusRouter/getOneMenu.js
@@ -2,7 +2,7 @@ import axios from "axios";
 
 import processMenu from "./processMenu";
 import queryBuilder from "../../util/queryBuilder";
-import { MENUS_URI } from "../../config/constants";
+import { MENUS_URI, YD_VERSION } from "../../config/constants";
 
 /*
  *   getOneMenu(query)
@@ -18,7 +18,7 @@ import { MENUS_URI } from "../../config/constants";
  */
 export default async function getOneMenu(query) {
     const location = query.location;
-    const endpoint = MENUS_URI + queryBuilder({ version: 3, location });
+    const endpoint = MENUS_URI + queryBuilder({ version: YD_VERSION, location });
     const response = await axios.get(endpoint);
     return processMenu(response.data, query);
 }


### PR DESCRIPTION
## Usage
`GET` and `POST` requests to `/api/favorites` now expect only the string portion of the expo token (e.g. `ExponentPushToken[1234] -> 1234`). Firestore still stores the token in the former form on the backend.