### PR TITLE
server/zm-favoritesWithName

### DIFF
--- a/server/src/config/constants.js
+++ b/server/src/config/constants.js
@@ -10,7 +10,7 @@ export const E_NO_API_RES = "Empty object returned from YaleDining API";
 
 export const E_BAD_LOC_REQ = "Invalid location request";
 export const E_BAD_MENU_REQ = "Invalid menu request";
-export const E_BAD_FAVE_POST_REQ = "Push token and item ID are required";
+export const E_BAD_FAVE_POST_REQ = "Push token, item ID, and item name are required";
 export const E_BAD_FAVE_GET_REQ = "Expo token is required";
 
 export const E_DB_READ = "Error getting document: ";

--- a/server/src/routers/FavoritesRouter/FavoritesRouter.js
+++ b/server/src/routers/FavoritesRouter/FavoritesRouter.js
@@ -18,7 +18,11 @@ router
     })
     .post("/", async (req, res) => {
         try {
-            await addFavorite(req.body.token, req.body.menuitemid);
+            await addFavorite(
+                req.body.token,
+                req.body.menuitemid,
+                req.body.name
+            );
             res.sendStatus(200);
         } catch (e) {
             console.error(e);

--- a/server/src/routers/FavoritesRouter/addFavorite.js
+++ b/server/src/routers/FavoritesRouter/addFavorite.js
@@ -3,8 +3,8 @@ import firestore from "../../config/firebase/firebaseConfig";
 
 import { E_BAD_FAVE_POST_REQ, E_DB_WRITE } from "../../config/constants";
 
-export default async function addFavorite(token, menuItemID) {
-    if (!token || !menuItemID) {
+export default async function addFavorite(token, menuItemID, menuItemName) {
+    if (!token || !menuItemID || !menuItemName) {
         throw new Error(E_BAD_FAVE_POST_REQ);
     }
     const expoToken = `ExponentPushToken[${token}]`;
@@ -14,6 +14,9 @@ export default async function addFavorite(token, menuItemID) {
         });
         await firestore.doc("favorites/users").update({
             [token]: firebase.firestore.FieldValue.arrayUnion(menuItemID)
+        });
+        await firestore.doc("menus/menuItems").update({
+            [menuItemID]: menuItemName
         });
     } catch (e) {
         throw new Error(E_DB_WRITE + e);

--- a/server/src/routers/FavoritesRouter/getFavorites.js
+++ b/server/src/routers/FavoritesRouter/getFavorites.js
@@ -4,20 +4,24 @@ import * as constants from "../../config/constants";
 
 export default async function getFavorites(token) {
     let usersDoc = undefined;
+    let menusDoc = undefined;
     try {
         usersDoc = await firestore.doc("favorites/users").get();
+        menusDoc = await firestore.doc("menus/menuItems").get();
     } catch (e) {
         throw new Error(constants.E_DB_READ + e);
     }
     if (!usersDoc.exists) {
         throw new Error(constants.E_DB_NOENT + "favorites/users");
+    } else if (!menusDoc.exists) {
+        throw new Error(constants.E_DB_NOENT + "menus/menuItems");
     } else if (!token) {
         throw new Error(constants.E_BAD_FAVE_GET_REQ);
     }
     const expoToken = `ExponentPushToken[${token}]`;
     var menuItems = {};
     usersDoc.data()[expoToken]
-        ? usersDoc.data()[expoToken].forEach(item => (menuItems[item] = true))
+        ? usersDoc.data()[expoToken].forEach(item => (menuItems[item] = menusDoc.data()[item]))
         : await firestore.doc("favorites/users").update({ [expoToken]: [] });
     return menuItems;
 }


### PR DESCRIPTION
## Usage

`POST` requests to `/api/favorites` must now contain the fields:
```
{
    token,
    menuitemid,
    name
}
```
The name of the item will be stored in a new Firebase document which will map menu item IDs to readable names. 

`GET` requests to `api/favorites` now return a list of the form
```
[{id: name}, ...]
```
where `name` is fetched from the database cache at each request.