### PR TITLE
client/cvm-slow-top-tabs-fix (in MenuView)

### DIFF
--- a/client/app/components/DV2ScrollView.js
+++ b/client/app/components/DV2ScrollView.js
@@ -18,8 +18,8 @@ export class DV2ScrollView extends React.Component {
                         ...styles.font.size.large, 
                         ...styles.font.color.primary}}>
                         {this.props.title}
-                        </Text>
-                    {this.props.array.map((element, index) => {
+                    </Text>
+                    {(this.props.array || []).map((element, index) => {
                         return this.props.render(element, index)
                     })}
                 </ScrollView>


### PR DESCRIPTION
# Changes
The tabs were a bit slow on `onPress` on the meal categories in the `MenuView`. You would press a tab and it would freeze the app for a second before highlighting the tab you had selected The rendering of the new items was the cause of the delay. I introduced some slight async into the selecting of the tabs in `MenuView` and an `isLoading` state. Woo!