### PR TITLE
Removing searchbar

### DIFF
--- a/client/app/views/MenuView.js
+++ b/client/app/views/MenuView.js
@@ -9,7 +9,6 @@ import BottomTabs from '../components/BottomTabs';
 import CenterTextView from '../components/CenterTextView';
 import Dish from '../components/Dish';
 import Header from '../components/Header';
-import Searchbar from '../components/Searchbar';
 import TopTabs from '../components/TopTabs';
 
 import styles from '../config/styles';
@@ -148,9 +147,6 @@ class MenuView extends Component {
                 {hasLoadedSuccessfully &&
                     <View style={{ flex: 1 }}>
                         <Header canGoBack title={!hasLoadedSuccessfully ? 'Loading...' : this.props.menusList.data.location} />
-                        <AnimatedListItem key="searchbar" index={0}>
-                            <Searchbar autoUpdate onSearch={this.performSearch} onChangeText={this.updateSearchTerm} />
-                        </AnimatedListItem>
                         <AnimatedListItem key="toptabs" index={3}>
                             <TopTabs tabButtons={this.dayTabButtons()} />
                             <TopTabs tabButtons={this.dynamicTabButtons()} />


### PR DESCRIPTION
Took out the searchbar bc it has a lot of issues:
1. Search doesn't work properly
2. Keyboard doesn't go down when you click the tabs, only when you click the sliver of scrollview area.
3. It's too big
4. My work on a drop down is on hold for the above reasons plus the fact that sizing needs to be discussed if we want to fit the magnifying glass icon in the header