### PR TITLE
client/dd-MenuItemView goes back to FavoritesView

### DIFF
--- a/client/app/config/routes.js
+++ b/client/app/config/routes.js
@@ -17,7 +17,8 @@ const AllergensRoutes = {
 }
 
 const FavoritesRoutes = {
-    FavoritesView: { screen: FavoritesView }
+    FavoritesView: { screen: FavoritesView },
+    MenuItemView: { screen: MenuItemView },
 }
 
 const DiningHallRoutes = {


### PR DESCRIPTION
Now back arrow from viewing menu item when reached from FavoritesView goes back to FavoritesView, not DiningHallsView.