### PR TITLE
Client/dd scrunch menu view tabs

### DIFF
--- a/client/app/components/TopTabs.js
+++ b/client/app/components/TopTabs.js
@@ -73,7 +73,7 @@ const tabStyles = StyleSheet.create({
     touchables: {
         alignItems: 'center',
         justifyContent: 'center',
-        paddingVertical: 8,
+        paddingVertical: 10,
     }
 })
 

--- a/client/app/components/TopTabs.js
+++ b/client/app/components/TopTabs.js
@@ -64,7 +64,7 @@ class TopTabs extends Component {
 
 const tabStyles = StyleSheet.create({
     container: {
-        padding: 10
+        paddingHorizontal: 5,
     },
     topTabs: {
         flexDirection: 'row',
@@ -73,8 +73,7 @@ const tabStyles = StyleSheet.create({
     touchables: {
         alignItems: 'center',
         justifyContent: 'center',
-        paddingTop: 10,
-        paddingBottom: 10,
+        paddingVertical: 8,
     }
 })
 

--- a/client/app/config/styles.js
+++ b/client/app/config/styles.js
@@ -67,46 +67,45 @@ export default styles = {
         
 
     },
-    container:
-        StyleSheet.create({
-            withPadding: {
-                margin: 20
+    container: StyleSheet.create({
+        withPadding: {
+            margin: 20
+        },
+        withPaddingSmall: {
+            margin: spacingSizes.small
+        },
+        dropShadow: {
+            shadowColor: "#000",
+            shadowOffset: {
+                width: 0,
+                height: 5,
             },
-            withPaddingSmall: {
-                margin: spacingSizes.small
-            },
-            dropShadow: {
-                shadowColor: "#000",
-                shadowOffset: {
-                    width: 0,
-                    height: 5,
-                },
-                shadowOpacity: 0.16,
-                shadowRadius: 6.68,
+            shadowOpacity: 0.16,
+            shadowRadius: 6.68,
 
-                elevation: 11,
-            },
-            backgroundColorPrimary: {
-                backgroundColor: colors.primary
-            },
-            spaceAbove: {
-                marginTop: 20
-            },
-            spaceBelow: {
-                marginBottom: 20
-            },
-            flexRow: {
-                flexWrap: 'wrap',
-                alignItems: 'center',
-                flexDirection: 'row'
-            },
-            center: {
-                flex: 1,
-                justifyContent: 'center',
-                alignItems: 'center',
-                height: '100%',
-            }
-        }),
+            elevation: 11,
+        },
+        backgroundColorPrimary: {
+            backgroundColor: colors.primary
+        },
+        spaceAbove: {
+            marginTop: 20
+        },
+        spaceBelow: {
+            marginBottom: 20
+        },
+        flexRow: {
+            flexWrap: 'wrap',
+            alignItems: 'center',
+            flexDirection: 'row'
+        },
+        center: {
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '100%',
+        }
+    }),
     spacing: {
         around: StyleSheet.create({
             small: {
@@ -126,5 +125,13 @@ export default styles = {
                 marginTop: spacingSizes.medium
             }
         }),
-    }
+    },
+    topTabs: StyleSheet.create({
+        withPaddingTop: {
+            paddingTop: 5,
+        },
+        withPaddingBottom: {
+            paddingBottom: 5,
+        }
+    }),
 }

--- a/client/app/views/AllergensView.js
+++ b/client/app/views/AllergensView.js
@@ -46,7 +46,12 @@ class AllergensView extends Component {
         return (
             <View style={{ flex: 1 }}>
                 <Header title="Menu Filters" />
-                <TopTabs tabButtons={this.tabButtons} />
+                <View style={{
+                    ...styles.topTabs.withPaddingTop,
+                    ...styles.topTabs.withPaddingBottom,
+                }}>
+                    <TopTabs tabButtons={this.tabButtons} />
+                </View>
                 <Text style={{ 
                         ...styles.font.type.primaryBold, 
                         ...styles.font.size.large, 

--- a/client/app/views/MenuItemView.js
+++ b/client/app/views/MenuItemView.js
@@ -43,7 +43,12 @@ class MenuItemView extends Component {
         return (
             <View style={{ flex: 1 }}>
                 <Header canGoBack title={this.props.menuItem.isLoading ? 'Loading...' : this.props.menuItem.data.name} />
-                <TopTabs tabButtons={this.tabButtons} />
+                <View style={{
+                    ...styles.topTabs.withPaddingTop,
+                    ...styles.topTabs.withPaddingBottom,
+                }}>
+                    <TopTabs tabButtons={this.tabButtons} />
+                </View>
                 <View style={{flex: 1}}>
                     {!this.props.menuItem.isLoading && this.state.selectedTabName == 'Nutrition' && <NutritionInfo />}
                     {!this.props.menuItem.isLoading && this.state.selectedTabName == 'Allergens' && <AllergenList />}

--- a/client/app/views/MenuView.js
+++ b/client/app/views/MenuView.js
@@ -163,10 +163,13 @@ class MenuView extends Component {
                 {hasLoadedSuccessfully &&
                     <View style={{ flex: 1 }}>
                         <AnimatedListItem key="toptabs" index={3}>
-                            <View style={{paddingTop: 5}}>
+                            <View style={{...styles.topTabs.withPaddingTop}}>
                                 <TopTabs tabButtons={this.dayTabButtons()} />
                             </View>
-                            <View style={{paddingTop: 2, paddingBottom: 5}}>
+                            <View style={{
+                                paddingTop: 2, 
+                                ...styles.topTabs.withPaddingBottom
+                            }}>
                                 <TopTabs tabButtons={this.dynamicTabButtons()} />
                             </View>
                         </AnimatedListItem>

--- a/client/app/views/MenuView.js
+++ b/client/app/views/MenuView.js
@@ -163,8 +163,12 @@ class MenuView extends Component {
                 {hasLoadedSuccessfully &&
                     <View style={{ flex: 1 }}>
                         <AnimatedListItem key="toptabs" index={3}>
-                            <TopTabs tabButtons={this.dayTabButtons()} />
-                            <TopTabs tabButtons={this.dynamicTabButtons()} />
+                            <View style={{paddingTop: 5}}>
+                                <TopTabs tabButtons={this.dayTabButtons()} />
+                            </View>
+                            <View style={{paddingTop: 2, paddingBottom: 5}}>
+                                <TopTabs tabButtons={this.dynamicTabButtons()} />
+                            </View>
                         </AnimatedListItem>
                         {!this.state.isLoading &&
                             <AnimatedListItem key="hourstext" index={4}>


### PR DESCRIPTION
The tabs are much closer together and also have less padding around the edges, as I showed off in class. To accomplish this, I have everything that uses top tabs use them inside a view, with the top and bottom margins set in styles.js. This way I could get rid of the top or bottom padding depending on what I needed in MenuView. This also means that anytime topTabs are used, they should be in a view with style={{...}} using the stylesheet for topTabs. 

![image](https://user-images.githubusercontent.com/21990843/56327662-59e1fc00-6149-11e9-8562-bfcfb8e0c793.png)
