### PR TITLE
server/zm-cachedMenusFix

### DIFF
--- a/server/src/config/constants.js
+++ b/server/src/config/constants.js
@@ -23,11 +23,3 @@ export const E_CODE_IS = "The error code is";
 
 export const STATUS_OK = "ok";
 export const STATUS_ERROR = "error";
-
-export const emptyMenu = {
-    contBreakfast: [],
-    hotBreakfast: [],
-    brunch: [],
-    lunch: [],
-    dinner: []
-}

--- a/server/src/config/constants.js
+++ b/server/src/config/constants.js
@@ -23,3 +23,11 @@ export const E_CODE_IS = "The error code is";
 
 export const STATUS_OK = "ok";
 export const STATUS_ERROR = "error";
+
+export const emptyMenu = {
+    contBreakfast: [],
+    hotBreakfast: [],
+    brunch: [],
+    lunch: [],
+    dinner: []
+}

--- a/server/src/routers/MenusRouter/getCachedMenu.js
+++ b/server/src/routers/MenusRouter/getCachedMenu.js
@@ -1,4 +1,4 @@
-import { E_DB_NOENT, emptyMenu } from "../../config/constants";
+import { E_DB_NOENT } from "../../config/constants";
 
 export default async function getCachedMenu(location, todayDoc, tomorrowDoc) {
     console.log(`Fetching data for ${location} from Firestore cache...`);

--- a/server/src/routers/MenusRouter/getCachedMenu.js
+++ b/server/src/routers/MenusRouter/getCachedMenu.js
@@ -42,5 +42,5 @@ function isFresh(timestamp) {
 }
 
 function isEmpty(menu) {
-    return Object.keys(menu).map(meal => menu[meal].length).length > 0;
+    return Object.keys(menu).length > 0;
 }

--- a/server/src/routers/MenusRouter/getCachedMenu.js
+++ b/server/src/routers/MenusRouter/getCachedMenu.js
@@ -13,10 +13,10 @@ export default async function getCachedMenu(location, todayDoc, tomorrowDoc) {
     var menu, timestamp;
     ({ menu, timestamp } =
         location in todayDoc.data() && todayDoc.data()[location]);
-    const today = isFresh(timestamp) ? menu : emptyMenu;
+    const today = isFresh(timestamp) ? menu : {};
     ({ menu, timestamp } =
         location in tomorrowDoc.data() && tomorrowDoc.data()[location]);
-    const tomorrow = isFresh(timestamp) ? menu : emptyMenu;
+    const tomorrow = isFresh(timestamp) ? menu : {};
 
     !isEmpty(today) && !isEmpty(tomorrow)
         ? console.log("Fetched menus from Firestore.")


### PR DESCRIPTION
## Updates
This change makes it so that the backend prefers to return cached data if it exists. Because the caching job will run every hour, it is much more likely that the cache has good data than the API, so I made the design decision to always prefer cached data. This will enable us to return menus for the next day when the API goes down overnight, for example (once the rollover function is also implemented). Note that if the cache only has bad data, the retry logic will still fall back to calling the API.