### PR TITLE
filtering supported, dietary restrictions page removed

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -26,7 +26,7 @@ import { getFavorites } from './app/redux/actions/FavoritesActions';
 import BottomTabs from './app/components/BottomTabs';
 
 // Configuring logger for the state of our app
-const loggerMiddleware = createLogger({ predicate: (getState, action) => false});
+const loggerMiddleware = createLogger({ predicate: (getState, action) => true});
 
 // Configuring our navigation middleware
 const Router = MasterView;

--- a/client/app/components/Dish.js
+++ b/client/app/components/Dish.js
@@ -51,7 +51,8 @@ export class Dish extends Component {
         borderColor: colors.primary,
         borderRadius: 20,
         paddingHorizontal: 10,
-        paddingVertical: 15
+        paddingVertical: 15,
+        opacity: .5
     }
 
     handlePress = async () => {

--- a/client/app/components/Dish.js
+++ b/client/app/components/Dish.js
@@ -41,6 +41,19 @@ export class Dish extends Component {
         paddingVertical: 15
     }
 
+    filteredDishStyle = {
+        ...styles.container.spaceBelowSmall,
+        ...styles.container.flexRow,
+        ...styles.container.dropShadowSmall,
+        justifyContent: 'space-between',
+        backgroundColor: '#D0D1D8',
+        borderWidth: 1,
+        borderColor: colors.primary,
+        borderRadius: 20,
+        paddingHorizontal: 10,
+        paddingVertical: 15
+    }
+
     handlePress = async () => {
         // TODO: change the favorited status of the dish
         const token = this.props.userInformation.notificationID;
@@ -75,7 +88,7 @@ export class Dish extends Component {
     render() {
         return (
             <ScaleInOut pose={this.state.isLoading ? 'exit' : 'enter'}>
-                <View style={this.dishStyle}>
+                <View style={this.props.filtered ? this.filteredDishStyle : this.dishStyle}>
                     <TouchableOpacity
                         style={{ width: '80%' }}
                         onPress={() => {

--- a/client/app/redux/actions/FilterActions.js
+++ b/client/app/redux/actions/FilterActions.js
@@ -1,0 +1,55 @@
+import * as types from './types';
+import { get } from '../../lib/api-utility';
+
+export function getFilters(expoToken) {
+    const request = () => {
+        return { type: types.GET_FILTERS_REQUEST }
+    }
+
+    const success = (filters) => {
+        return {
+            type: types.GET_FILTERS_SUCCESS,
+            payload: {
+                filters: filters
+            }
+        }
+    }
+
+    const failure = (errorMessage) => {
+        return {
+            type: types.GET_FILTERS_FAILURE,
+            errorMessage: errorMessage
+        }
+    }
+
+    return async (dispatch) => {
+        dispatch(request()); // tell Redux we're about to make that request
+        try {
+            const filters = await get("/api/filters", { 
+                token: expoToken
+             });
+            dispatch(success(filters)); // If successful, dispatch it to Redux
+        } catch (e) {
+            dispatch(failure(e.message));
+        }
+    }
+}
+
+export function addFilter(menuItemID, menuItemName) {
+    return {
+        type: types.ADD_FILTER,
+        payload: {
+            menuItemID,
+            menuItemName
+        }
+    }
+}
+
+export function removeFilter(menuItemID) {
+    return {
+        type: types.REMOVE_FILTER,
+        payload: {
+            menuItemID
+        }
+    }
+}

--- a/client/app/redux/lib/stateProperties.js
+++ b/client/app/redux/lib/stateProperties.js
@@ -13,6 +13,7 @@ export default stateProperties = {
     menusList: 'menusList',
     favoritesList: 'favoritesList',
     allergensList: 'allergensList',
+    filtersList: 'filtersList',
     menuItem: 'menuItem',
     userInformation: 'userInformation',
 }

--- a/client/app/redux/reducers/AllergenReducers.js
+++ b/client/app/redux/reducers/AllergenReducers.js
@@ -17,7 +17,7 @@ const initialState = {
     Vegan: false, 
     Pork: false, 
     FishSeafood: false, 
-    Soy: false, 
+    Soy: true, 
     Wheat: false, 
     Gluten: false, 
     Vegetarian: false, 

--- a/client/app/redux/reducers/FilterReducers.js
+++ b/client/app/redux/reducers/FilterReducers.js
@@ -1,0 +1,69 @@
+// Helper function to create the reducer without switch statements
+import createReducer from '../lib/createReducer';
+
+// All the action types (messages) you could possibly have
+import * as types from '../actions/types';
+
+/* The initial state of these values. 
+ * You can declare anything you'd like here.
+ * */
+const initialState = {
+    isLoading: true,
+    errorMessage: "",
+    data: undefined,
+}
+
+/* 
+ * It updates the initial state above based on
+ * the action messages it receives (along with the previous state)
+ * and then you can modify it accordingly 
+ * */
+export const filtersList = createReducer(initialState, {
+    [types.GET_FILTERS_REQUEST](state, action) {
+        return {
+            ...state,
+            hasError: false,
+            isLoading: true // we've initiated the request, set loading to true
+        }
+    },
+    [types.GET_FILTERS_SUCCESS](state, action) {
+        const filtersObject = action.payload.filters;
+        return {
+            ...state,
+            data: filtersObject,
+            hasError: false,
+            isLoading: false // set isLoading to false so UI shows the filtersObject
+        }
+    },
+    [types.GET_FILTERS_FAILURE](state, action) {
+        return {
+            ...state,
+            data: undefined,
+            hasError: true,
+            isLoading: false, // set isLoading to false - not still loading :(
+            errorMessage: action.errorMessage // can add to display error msg
+        }
+    },
+
+    [types.ADD_FILTER](state, action) {
+        const filtersObject = state.data || {};
+        const { menuItemID, menuItemName } = action.payload;
+        filtersObject[menuItemID] = menuItemName;
+
+        return {
+            ...state,
+            data: filtersObject
+        }
+    },
+    [types.REMOVE_FILTER](state, action) {
+        const filtersObject = state.data || {};
+        const menuItemID = action.payload.menuItemID;
+        
+        delete filtersObject[menuItemID];
+        
+        return {
+            ...state,
+            data: filtersObject
+        }
+    }
+})

--- a/client/app/views/AllergensView.js
+++ b/client/app/views/AllergensView.js
@@ -13,6 +13,7 @@ import allergens from '../config/allAllergens';
 import restrictions from '../config/allRestrictions';
 import BottomTabs from '../components/BottomTabs';
 import TopTabs from '../components/TopTabs';
+import { post } from '../lib/api-utility';
 
 
 
@@ -95,6 +96,8 @@ class AllergensView extends Component {
                 </Text>
                 <Switch 
                     value={this.props.allergensList[allergen]} 
+                    // TODO: Below line to be used once /api/filters implemented
+                    // value = {this.props.filtersList.data[allergen]}
                     onValueChange={(value) => this.SwitchChange(value, allergen)}
                 />
             </View>
@@ -104,6 +107,29 @@ class AllergensView extends Component {
     SwitchChange(value, allergen) {
         this.props.toggleAllergens(value, allergen);
     }
+    //OnSwitch to be used once /api/filters is implemented
+    OnSwitch = async (value, allergen) => {
+        const token = this.props.userInformation.notificationID;
+        const postConfig = {
+            token,
+            allergen
+        }
+        try {
+            if (value == true){
+                await post('/api/filters/delete', postConfig);
+                this.props.removeFilter(allergen);
+            }
+            else {
+                await post('api/filters', postConfig);
+                this.props.addFilter(allergen);
+            }
+        } catch (e) {
+            console.error("Filter add/remove error", e.message);
+        }
+
+        
+
+    }
 }
 
-export default connectToRedux(AllergensView, ['allergensList']);
+export default connectToRedux(AllergensView, ['allergensList', 'userInformation', 'filtersList']);

--- a/client/app/views/AllergensView.js
+++ b/client/app/views/AllergensView.js
@@ -50,18 +50,21 @@ class AllergensView extends Component {
                     ...styles.topTabs.withPaddingTop,
                     ...styles.topTabs.withPaddingBottom,
                 }}>
-                    <TopTabs tabButtons={this.tabButtons} />
+                    {/* <TopTabs tabButtons={this.tabButtons} /> */}
                 </View>
                 <Text style={{ 
                         ...styles.font.type.primaryBold, 
                         ...styles.font.size.large, 
                         ...styles.font.color.primary,
                         paddingHorizontal: 10}}>
-                        {this.state.selectedTabName == 'Dietary Restrictions' ? 'I am...' : 'I cannot eat...'}
+                        {/* {this.state.selectedTabName == 'Dietary Restrictions' ? 'I am...' : 'I cannot eat...'} */}
+                        I cannot eat...
                 </Text>
                 <View style={{flex: 1}}>
                     <DV2ScrollView 
-                        array={this.state.selectedTabName == 'Dietary Restrictions' ? restrictions : allergens}
+                        // array={this.state.selectedTabName == 'Dietary Restrictions' ? restrictions : allergens}
+                        array={allergens}
+
                         render={(allergen) => this.renderAllergen(allergen)}
                     />
                 </View>

--- a/client/app/views/MenuView.js
+++ b/client/app/views/MenuView.js
@@ -207,13 +207,36 @@ class MenuView extends Component {
         )
     }
 
+    isFiltered = (dish) => {
+        const filters = this.props.allergensList;
+        if (filters.Vegetarian && !dish.isVegetarian) {
+            return true;
+        }
+        if (filters.GlutenFree && !dish.isGlutenFree) {
+            return true;
+        }
+        if (filters.Vegan && !dish.isVegan) {
+            return true;
+        }
+        else {
+            for (index = 0; index < dish.allergens.length; index++) {
+                if (filters[dish.allergens[index]]){
+                    return true;
+                } 
+            }
+        }
+        return false;
+    }
+
     renderMenu = (dish, index) => {
+       
+        const filtered = this.isFiltered(dish);
         return (
             <AnimatedListItem key={dish.name} index={index}>
-                <Dish key={dish.name} dish={dish} />
+                <Dish key={dish.name} dish={dish} filtered={filtered}/>
             </AnimatedListItem>
         );
     }
 }
 
-export default connectToRedux(MenuView, ['menusList', 'diningHallsList']);
+export default connectToRedux(MenuView, ['menusList', 'diningHallsList', 'allergensList']);

--- a/client/app/views/MenuView.js
+++ b/client/app/views/MenuView.js
@@ -209,6 +209,8 @@ class MenuView extends Component {
 
     isFiltered = (dish) => {
         const filters = this.props.allergensList;
+        // TODO: below to be used once /api/filters implemented
+        // const filters = this.props.filtersList.data;
         if (filters.Vegetarian && !dish.isVegetarian) {
             return true;
         }
@@ -239,4 +241,4 @@ class MenuView extends Component {
     }
 }
 
-export default connectToRedux(MenuView, ['menusList', 'diningHallsList', 'allergensList']);
+export default connectToRedux(MenuView, ['menusList', 'diningHallsList', 'allergensList', 'filtersList']);


### PR DESCRIPTION
This branch adds in logic checks during renderMenu to determine if an item should be filtered or not when viewing the menu.

Currently, a filtered menu item appears in place with a slightly greyed-out background. Filtering doesn't appear to have affected speed much.

One major issue is that it's clear that Yale's classification of vegan, vegetarian, and gluten-free foods is totally wrong. Including these dietary restrictions is pretty pointless then even though it would have been really helpful. If the app ever sees a wide release, we should try to get YD to fix that.

Next steps would be to store each users' filtering preferences (A list of each allergen along with a boolean true/false) in Firebase and pull them when the app opens like we do now for favorites. That should be the last update necessary for working filters

Edit Apr 22 4:54 pm: I've gone in and added new actions and reducers for filtering, and added commented out lines of code that make use of them that can be un-commented once the backend filtering is written