### PR TITLE
Added a route for /api/preferences

### DIFF
--- a/server/src/config/constants.js
+++ b/server/src/config/constants.js
@@ -11,8 +11,10 @@ export const E_NO_API_RES = "Empty object returned from YaleDining API";
 export const E_BAD_LOC_REQ = "Invalid location request";
 export const E_BAD_MENU_REQ = "Invalid menu request";
 export const E_BAD_MENU_ITEM_REQ = "MenuItemID is required";
-export const E_BAD_FAVE_POST_REQ = "Push token, item ID, and item name are required";
+export const E_BAD_FAVE_POST_REQ = "Expo token, item ID, and item name are required";
 export const E_BAD_FAVE_GET_REQ = "Expo token is required";
+export const E_BAD_PREF_POST_REQ = "Expo token and preference field are required";
+export const E_BAD_PREF_GET_REQ = "Expo token is required";
 
 export const E_DB_READ = "Error getting document: ";
 export const E_DB_WRITE = "Could not write document: ";

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -9,6 +9,7 @@ import FavoritesRouter from "./routers/FavoritesRouter/FavoritesRouter";
 import TestPushRouter from "./routers/TestPushRouter/TestPushRouter";
 import PopulateRouter from "./routers/PopulateRouter/PopulateRouter";
 import CacheFavoritesRouter from "./routers/CacheFavoritesRouter/CacheFavoritesRouter";
+import PreferencesRouter from "./routers/PreferencesRouter/PreferencesRouter";
 
 import sendNotifications from "./cron/notifications/sendNotifications";
 import updateMenuItemNames from "./cron/cleanup/updateMenuItemNames";
@@ -30,6 +31,7 @@ server.use("/api/favorites", FavoritesRouter);
 server.use("/api/testPush", TestPushRouter);
 server.use("/api/populate", PopulateRouter);
 server.use("/api/cacheFavorites", CacheFavoritesRouter);
+server.use("/api/preferences", PreferencesRouter);
 
 server.listen(PORT, e => e && console.error(e));
 

--- a/server/src/routers/PreferencesRouter/PreferencesRouter.js
+++ b/server/src/routers/PreferencesRouter/PreferencesRouter.js
@@ -1,0 +1,40 @@
+import express from "express";
+
+import addPreference from "./removePreference";
+import removePreference from "./addPreference";
+
+const router = express.Router();
+
+router
+    .get("/", async (req, res) => {
+        try {
+            const { token } = req.query;
+            const preferences = await getPreferences(token);
+            res.send(preferences).status(200);
+        } catch (e) {
+            console.error(e);
+            res.send(e).status(500);
+        }
+    })
+    .post("/", async (req, res) => {
+        try {
+            const { token, preference } = req.body;
+            await addPreference(token, preference);
+            res.sendStatus(200);
+        } catch (e) {
+            console.error(e);
+            res.send(e).status(500);
+        }
+    })
+    .post("/delete", async (req, res) => {
+        try {
+            const { token, preference } = req.body;
+            await removePreference(token, preference);
+            res.sendStatus(200);
+        } catch (e) {
+            console.error(e);
+            res.send(e).status(500);
+        }
+    });
+
+export default router;

--- a/server/src/routers/PreferencesRouter/addPreference.js
+++ b/server/src/routers/PreferencesRouter/addPreference.js
@@ -1,0 +1,38 @@
+import firestore from "../../config/firebase/firebaseConfig";
+
+import { E_BAD_PREF_POST_REQ, E_DB_WRITE } from "../../config/constants";
+
+export default async function removePreference(token, preference) {
+    if (!token || !preference) {
+        throw new Error(E_BAD_PREF_POST_REQ);
+    }
+    try {
+        const preferences = await firestore.doc("preferences/users").get();
+        token in preferences.data()
+            ? await firestore.doc("preferences/users").update({
+                  [token]: { ...preferences.data()[token], preference: false }
+              })
+            : await firestore.doc("preferences/users").set({
+                  [token]: { ...emptyPreferences, preference: true }
+              });
+    } catch (e) {
+        throw new Error(E_DB_WRITE + e);
+    }
+}
+
+const emptyPreferences = {
+    vegetarian: false,
+    vegan: false,
+    glutenFree: false,
+    alcohol: false,
+    nuts: false,
+    shellfish: false,
+    peanut: false,
+    dairy: false,
+    eggs: false,
+    pork: false,
+    fishSeafood: false,
+    soy: false,
+    wheat: false,
+    gluten: false
+};

--- a/server/src/routers/PreferencesRouter/getPreferences.js
+++ b/server/src/routers/PreferencesRouter/getPreferences.js
@@ -1,0 +1,37 @@
+import firestore from "../../config/firebase/firebaseConfig";
+
+import * as constants from "../../config/constants";
+
+export default async function getPreferences(token) {
+    var preferencesDoc = undefined;
+    try {
+        preferencesDoc = await firestore.doc("preferences/users").get();
+    } catch (e) {
+        throw new Error(constants.E_DB_READ + e);
+    }
+    if (!preferencesDoc.exists) {
+        throw new Error(constants.E_DB_NOENT + "favorites/users");
+    } else if (!token) {
+        throw new Error(constants.E_BAD_PREF_GET_REQ);
+    }
+    return token in preferencesDoc.data()
+        ? preferencesDoc.data()[token]
+        : emptyPreferences;
+}
+
+const emptyPreferences = {
+    vegetarian: false,
+    vegan: false,
+    glutenFree: false,
+    alcohol: false,
+    nuts: false,
+    shellfish: false,
+    peanut: false,
+    dairy: false,
+    eggs: false,
+    pork: false,
+    fishSeafood: false,
+    soy: false,
+    wheat: false,
+    gluten: false
+};

--- a/server/src/routers/PreferencesRouter/removePreference.js
+++ b/server/src/routers/PreferencesRouter/removePreference.js
@@ -1,0 +1,17 @@
+import firestore from "../../config/firebase/firebaseConfig";
+
+import { E_BAD_PREF_POST_REQ, E_DB_WRITE } from "../../config/constants";
+
+export default async function removePreference(token, preference) {
+    if (!token || !preference) {
+        throw new Error(E_BAD_PREF_POST_REQ);
+    }
+    try {
+        const preferences = await firestore.doc("preferences/users").get();
+        await firestore.doc("preferences/users").update({
+            [token]: { ...preferences[token], preference: false }
+        });
+    } catch (e) {
+        throw new Error(E_DB_WRITE + e);
+    }
+}


### PR DESCRIPTION
## Updates
Adds a route `/api/preferences` to retreive/set a user's preferences from Firestore. The routes are the same as `FavoritesRouter`: you can `POST` to `/` or `/delete` with the required body keys `token` and `preference`, or `GET` from `/` with a required query `token`. The response looks like:
```
{
    vegetarian: false,
    vegan: false,
    glutenFree: false,
    alcohol: false,
    nuts: false,
    shellfish: false,
    peanut: false,
    dairy: false,
    eggs: false,
    pork: false,
    fishSeafood: false,
    soy: false,
    wheat: false,
    gluten: false
};
```
and the possible values for `preference` are those keys.