### PR TITLE
Favorites view top tabs now have padding, style name generalized in styles.js

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -26,7 +26,7 @@ import { getFavorites } from './app/redux/actions/FavoritesActions';
 import BottomTabs from './app/components/BottomTabs';
 
 // Configuring logger for the state of our app
-const loggerMiddleware = createLogger({ predicate: (getState, action) => true});
+const loggerMiddleware = createLogger({ predicate: (getState, action) => false});
 
 // Configuring our navigation middleware
 const Router = MasterView;

--- a/client/app/config/styles.js
+++ b/client/app/config/styles.js
@@ -81,6 +81,12 @@ export default (styles = {
         withPaddingSmall: {
             margin: spacingSizes.small
         },
+        withPaddingTop: {
+            paddingTop: 5
+        },
+        withPaddingBottom: {
+            paddingBottom: 5
+        },
         dropShadowLarge: {
             shadowColor: "#000",
             shadowOffset: {
@@ -146,15 +152,7 @@ export default (styles = {
                 marginTop: spacingSizes.medium
             }
         })
-    },
-    topTabs: StyleSheet.create({
-        withPaddingTop: {
-            paddingTop: 5
-        },
-        withPaddingBottom: {
-            paddingBottom: 5
-        }
-    })
+    }
 });
 
 export const card = {

--- a/client/app/views/AllergensView.js
+++ b/client/app/views/AllergensView.js
@@ -50,8 +50,8 @@ class AllergensView extends Component {
             <View style={{ flex: 1 }}>
                 <Header title="Menu Filters" />
                 <View style={{
-                    ...styles.topTabs.withPaddingTop,
-                    ...styles.topTabs.withPaddingBottom,
+                    ...styles.container.withPaddingTop,
+                    ...styles.container.withPaddingBottom,
                 }}>
                     {/* <TopTabs tabButtons={this.tabButtons} /> */}
                 </View>

--- a/client/app/views/Favorites/FavoritesListAll.js
+++ b/client/app/views/Favorites/FavoritesListAll.js
@@ -30,7 +30,7 @@ const FavoritesListAll = (props) => {
 
     return (
             <View>
-                <Hint message="These are all the dishes you've favorited." />
+                <Hint message="These are all the dishes you've favorited so far." />
                 <DV2ScrollView 
                     array={Object.keys(props.favoritesList.data)}
                     render={(dishID) => renderFavesList(dishID)}

--- a/client/app/views/Favorites/MainView.js
+++ b/client/app/views/Favorites/MainView.js
@@ -9,6 +9,7 @@ import CenterTextView from '../../components/CenterTextView';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import FavoritesListAll from './FavoritesListAll';
 import FavoritesListServedToday from './FavoritesListServedToday';
+import styles from '../../config/styles';
 
 class MainView extends Component {
 
@@ -47,7 +48,7 @@ class MainView extends Component {
             );
         } else {
             return (
-            <View>
+            <View style={{...styles.container.withPaddingTop}}>
                 <TopTabs tabButtons={this.favoritesTabButtons} />
                 {this.state.selectedTab == this.allFavorites &&
                     <FavoritesListAll />

--- a/client/app/views/MenuItemView.js
+++ b/client/app/views/MenuItemView.js
@@ -48,8 +48,8 @@ class MenuItemView extends Component {
             <View style={{ flex: 1 }}>
                 <Header canGoBack title={this.props.menuItem.isLoading ? 'Loading...' : this.props.menuItem.data.name} />
                 <View style={{
-                    ...styles.topTabs.withPaddingTop,
-                    ...styles.topTabs.withPaddingBottom,
+                    ...styles.container.withPaddingTop,
+                    ...styles.container.withPaddingBottom,
                 }}>
                     <TopTabs tabButtons={this.tabButtons} />
                 </View>

--- a/client/app/views/MenuView.js
+++ b/client/app/views/MenuView.js
@@ -159,12 +159,12 @@ class MenuView extends Component {
                 {hasLoadedSuccessfully &&
                     <View style={{ flex: 1 }}>
                         <AnimatedListItem key="toptabs" index={3}>
-                            <View style={{...styles.topTabs.withPaddingTop}}>
+                            <View style={{...styles.container.withPaddingTop}}>
                                 <TopTabs tabButtons={this.dayTabButtons()} />
                             </View>
                             <View style={{
                                 paddingTop: 2, 
-                                ...styles.topTabs.withPaddingBottom
+                                ...styles.container.withPaddingBottom
                             }}>
                                 <TopTabs tabButtons={this.dynamicTabButtons()} />
                             </View>
@@ -216,7 +216,7 @@ class MenuView extends Component {
             return true;
         }
         else {
-            for (index = 0; index < dish.allergens.length; index++) {
+            for (var index = 0; index < dish.allergens.length; index++) {
                 if (filters[dish.allergens[index]]){
                     return true;
                 } 


### PR DESCRIPTION
### Changes
Top tabs in `Favorites/MainView.js` were too high up. Added the same padding values used in `MenuView` on the top tabs:
![image](https://user-images.githubusercontent.com/22136259/56628638-88177e00-6618-11e9-83a0-e38b66c144e0.png)

The name of the padding top style in `styles.js` was `topTabs.withPaddingTop`, but this style can be generalized to any component, so I moved it to `container.withPaddingTop` and changed it everywhere that occurred.