### PR TITLE
Client/zk favorites bug fix

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -26,7 +26,7 @@ import { getFavorites } from './app/redux/actions/FavoritesActions';
 import BottomTabs from './app/components/BottomTabs';
 
 // Configuring logger for the state of our app
-const loggerMiddleware = createLogger({ predicate: (getState, action) => false});
+const loggerMiddleware = createLogger({ predicate: (getState, action) => true});
 
 // Configuring our navigation middleware
 const Router = MasterView;

--- a/client/app/components/FavoriteServedTodayCard.js
+++ b/client/app/components/FavoriteServedTodayCard.js
@@ -23,22 +23,6 @@ class FavoriteServedTodayCard extends React.Component {
         return "Served at " + formatArrayAsString(locationsArray);
     }
 
-    // Temporary fix: if only a string is passed in, 
-    // Sets meal and lunch location to Unknown
-    getDishObject = (dishName) => {
-        const dish = {
-            name: "Nothing",
-            meal: "Lunch",
-            location: "Unknown" 
-        }
-        return dish
-    }
-    
-    isString = (dish) => {
-        return typeof dish === 'string' || dish instanceof String;
-    }
-    
-
     render() {
         const { favoriteDish } = this.props;
         // If favoriteDish is an object, proceed, otherwise put the string in an object

--- a/client/app/components/FavoriteServedTodayCard.js
+++ b/client/app/components/FavoriteServedTodayCard.js
@@ -25,18 +25,12 @@ class FavoriteServedTodayCard extends React.Component {
 
     render() {
         const { favoriteDish } = this.props;
-        // If favoriteDish is an object, proceed, otherwise put the string in an object
-        // const favDishObject = favoriteDish.name ? favoriteDish : getDishObject(favoriteDish);
-        var favDishObject = undefined;
-        
-        favDishObject = favoriteDish;
-           
-        
-        // const { name, meal, location } = favDishObject;
-        // const { name } = favDishObject;
-        const name = favDishObject.hasOwnProperty('name') ? favDishObject.name : favDishObject;
-        const meal = favDishObject.hasOwnProperty('meal') ? favDishObject.meal : ["UNKNOWN"];
-        const location = favDishObject.hasOwnProperty('location') ? favDishObject.location : ["UNKOWN"];
+
+        // populate variables based on that properties favoriteDish contains
+        // if doesn't contain name field, favoriteDish is just a string
+        const name = favoriteDish.hasOwnProperty('name') ? favoriteDish.name : favDishObject;
+        const meal = favoriteDish.hasOwnProperty('meal') ? favoriteDish.meal : ["UNKNOWN"];
+        const location = favoriteDish.hasOwnProperty('location') ? favoriteDish.location : ["UNKOWN"];
         
 
         const mealsString = this.formatMealsString(meal);

--- a/client/app/components/FavoriteServedTodayCard.js
+++ b/client/app/components/FavoriteServedTodayCard.js
@@ -24,24 +24,37 @@ class FavoriteServedTodayCard extends React.Component {
     }
 
     // Temporary fix: if only a string is passed in, 
-    // Set meal to Lunch and location to Hopper (randomly chosen)
+    // Sets meal and lunch location to Unknown
     getDishObject = (dishName) => {
         const dish = {
-            name: dishName,
-            meal: "Unknown",
-            location: "Unknown"
-             
+            name: "Nothing",
+            meal: "Lunch",
+            location: "Unknown" 
         }
         return dish
     }
     
+    isString = (dish) => {
+        return typeof dish === 'string' || dish instanceof String;
+    }
     
 
     render() {
         const { favoriteDish } = this.props;
         // If favoriteDish is an object, proceed, otherwise put the string in an object
-        const favDishObject = favoriteDish.name ? favoriteDish : getDishObject(favoriteDish);
-        const { name, meal, location } = favDishObject;
+        // const favDishObject = favoriteDish.name ? favoriteDish : getDishObject(favoriteDish);
+        var favDishObject = undefined;
+        
+        favDishObject = favoriteDish;
+           
+        
+        // const { name, meal, location } = favDishObject;
+        // const { name } = favDishObject;
+        const name = favDishObject.hasOwnProperty('name') ? favDishObject.name : favDishObject;
+        const meal = favDishObject.hasOwnProperty('meal') ? favDishObject.meal : ["UNKNOWN"];
+        const location = favDishObject.hasOwnProperty('location') ? favDishObject.location : ["UNKOWN"];
+        
+
         const mealsString = this.formatMealsString(meal);
         const locationsString = this.formatLocationsString(location);
 

--- a/client/app/components/FavoriteServedTodayCard.js
+++ b/client/app/components/FavoriteServedTodayCard.js
@@ -23,9 +23,25 @@ class FavoriteServedTodayCard extends React.Component {
         return "Served at " + formatArrayAsString(locationsArray);
     }
 
+    // Temporary fix: if only a string is passed in, 
+    // Set meal to Lunch and location to Hopper (randomly chosen)
+    getDishObject = (dishName) => {
+        const dish = {
+            name: dishName,
+            meal: "Unknown",
+            location: "Unknown"
+             
+        }
+        return dish
+    }
+    
+    
+
     render() {
         const { favoriteDish } = this.props;
-        const { name, meal, location } = favoriteDish;
+        // If favoriteDish is an object, proceed, otherwise put the string in an object
+        const favDishObject = favoriteDish.name ? favoriteDish : getDishObject(favoriteDish);
+        const { name, meal, location } = favDishObject;
         const mealsString = this.formatMealsString(meal);
         const locationsString = this.formatLocationsString(location);
 

--- a/client/app/config/formattedMealTypes.js
+++ b/client/app/config/formattedMealTypes.js
@@ -3,7 +3,8 @@ const formatted = {
     hotBreakfast: "Hot Breakfast",
     brunch: "Brunch",
     lunch: "Lunch",
-    dinner: "Dinner"
+    dinner: "Dinner",
+    "Unknown": "Unknown"
 }
 
 export default formatted;

--- a/client/app/views/Favorites/FavoritesListServedToday.js
+++ b/client/app/views/Favorites/FavoritesListServedToday.js
@@ -34,11 +34,18 @@ class FavoritesListServedToday extends React.Component {
         const dish = this.props.favoritesList.data[dishID];
 
         return (
+        <View>
+            {dish && 
             <AnimatedListItem key={dishID}>
                 <View style={{...styles.container.spaceBelowSmall}}>
                     <FavoriteServedTodayCard favoriteDish={dish} />
                 </View>
             </AnimatedListItem>
+        
+        }
+        </View>
+        
+           
         );
     }
 

--- a/client/app/views/Favorites/FavoritesListServedToday.js
+++ b/client/app/views/Favorites/FavoritesListServedToday.js
@@ -31,7 +31,7 @@ class FavoritesListServedToday extends React.Component {
     }
 
     renderFavesList = (dishID) => {
-        const dish = props.favoritesList.data[dishID];
+        const dish = this.props.favoritesList.data[dishID];
 
         return (
             <AnimatedListItem key={dishID}>
@@ -52,10 +52,10 @@ class FavoritesListServedToday extends React.Component {
 
         return (
                 <View style={{marginHorizontal: 10}}>
-                    <Hint message={prompts.hint} />
+                    <Hint message={this.prompts.hint} />
                     <DV2ScrollView 
-                        array={favoritesServedTodayArray}
-                        render={(dishID) => renderFavesList(dishID)}
+                        array={this.favoritesServedTodayArray}
+                        render={(dishID) => this.renderFavesList(dishID)}
                     />
                 </View>
         )


### PR DESCRIPTION
Problem fixed:
After navigating to FavoritesView, favoriting and unfavoriting items would cause type errors

Fix: 
Monitoring what type of data was being passed into FavoriteServedTodayCard (string, object, undefined) and populate the variables passed to ItemCard accordingly

Lingering issues:

Unfavoriting an item and favoriting again triggers warnings for duplicate keys
Items in favoritesList with only a name being served today have a card that just says "served at NONE"
Padding on FavoritesServedToday is way off